### PR TITLE
Use astropy custom config location

### DIFF
--- a/changelog/3.feature.rst
+++ b/changelog/3.feature.rst
@@ -1,0 +1,1 @@
+Add a dkist config file using custom location from astropy

--- a/dkist/__init__.py
+++ b/dkist/__init__.py
@@ -1,11 +1,8 @@
 import os
-from warnings import warn
 
 from pkg_resources import DistributionNotFound, get_distribution
 
-from astropy.config.configuration import (ConfigurationDefaultMissingError,
-                                          ConfigurationDefaultMissingWarning,
-                                          update_default_config)
+import astropy.config as _config
 from astropy.tests.helper import TestRunner
 
 from .dataset import Dataset  # noqa
@@ -16,29 +13,23 @@ except DistributionNotFound:
     # package is not installed
     __version__ = "unknown"
 
-# add these here so we only need to cleanup the namespace at the end
-config_dir = None
-
-if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
-    config_dir = os.path.dirname(__file__)
-    config_template = os.path.join(config_dir, __package__ + ".cfg")
-    if os.path.isfile(config_template):
-        try:
-            update_default_config(
-                __package__, config_dir, version=__version__)
-        except TypeError as orig_error:
-            try:
-                update_default_config(__package__, config_dir)
-            except ConfigurationDefaultMissingError as e:
-                wmsg = (e.args[0] +
-                        " Cannot install default profile. If you are "
-                        "importing from source, this is expected.")
-                warn(ConfigurationDefaultMissingWarning(wmsg))
-                del e
-            except Exception:
-                raise orig_error
+__all__ = ['test', 'Dataset', 'write_default_config']
 
 
-__all__ = ['test', 'Dataset']
+def write_default_config():
+    """
+    Writes out the template configuration file for this version of dkist.
+
+    This function will save a template config file for manual editing, if a
+    config file already exits this will write a config file appended with the
+    version number, to facilitate comparison of changes.
+
+    Returns
+    -------
+    filepath : `pathlib.Path` or `None`
+        The full path of the file written or `None` if no file was written.
+    """
+    return _config.write_default_config("dkist", "dkist")
+
 
 test = TestRunner.make_test_runner_in(os.path.dirname(__file__))

--- a/dkist/_dkist_init.py
+++ b/dkist/_dkist_init.py
@@ -1,2 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-# this indicates whether or not we are in the package's setup.py

--- a/dkist/config/__init__.py
+++ b/dkist/config/__init__.py
@@ -1,0 +1,9 @@
+import astropy.config as astropyconfig
+
+
+class ConfigNamespace(astropyconfig.ConfigNamespace):
+    rootname = 'dkist'
+
+
+class ConfigItem(astropyconfig.ConfigItem):
+    rootname = 'dkist'

--- a/dkist/config/__init__.py
+++ b/dkist/config/__init__.py
@@ -1,9 +1,8 @@
-import astropy.config as astropyconfig
+from astropy.config import ConfigNamespace, ConfigItem as _AstropyConfigItem
 
 
-class ConfigNamespace(astropyconfig.ConfigNamespace):
-    rootname = 'dkist'
+__all__ = ['ConfigItem', 'ConfigNamespace']
 
 
-class ConfigItem(astropyconfig.ConfigItem):
+class ConfigItem(_AstropyConfigItem):
     rootname = 'dkist'

--- a/dkist/config/__init__.py
+++ b/dkist/config/__init__.py
@@ -1,5 +1,5 @@
-from astropy.config import ConfigNamespace, ConfigItem as _AstropyConfigItem
-
+from astropy.config import ConfigItem as _AstropyConfigItem
+from astropy.config import ConfigNamespace
 
 __all__ = ['ConfigItem', 'ConfigNamespace']
 

--- a/dkist/dkist.cfg
+++ b/dkist/dkist.cfg
@@ -1,0 +1,3 @@
+[io]
+## Name of Preferred fits module
+# preferred_fits_library = 'astropy'

--- a/dkist/io/__init__.py
+++ b/dkist/io/__init__.py
@@ -1,12 +1,12 @@
+import dkist.config as _config
+
 from .fits import AstropyFITSLoader, BaseFITSLoader
-from .reference_collections import (BaseFITSArrayContainer, DaskFITSArrayContainer,
+from .reference_collections import (BaseFITSArrayContainer,
+                                    DaskFITSArrayContainer,
                                     NumpyFITSArrayContainer)
 
 __all__ = ['BaseFITSLoader', 'AstropyFITSLoader', 'BaseFITSArrayContainer',
            'NumpyFITSArrayContainer', 'DaskFITSArrayContainer', 'conf']
-
-
-import dkist.config as _config
 
 
 class Conf(_config.ConfigNamespace):

--- a/dkist/io/__init__.py
+++ b/dkist/io/__init__.py
@@ -1,3 +1,21 @@
 from .fits import AstropyFITSLoader, BaseFITSLoader
 from .reference_collections import (BaseFITSArrayContainer, DaskFITSArrayContainer,
                                     NumpyFITSArrayContainer)
+
+__all__ = ['BaseFITSLoader', 'AstropyFITSLoader', 'BaseFITSArrayContainer',
+           'NumpyFITSArrayContainer', 'DaskFITSArrayContainer', 'conf']
+
+
+import dkist.config as _config
+
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration Parameters for the IO Package.
+    """
+
+    preferred_fits_library = _config.ConfigItem('astropy',
+                                                "Name of the preferred FITS module.")
+
+
+conf = Conf()

--- a/dkist/io/__init__.py
+++ b/dkist/io/__init__.py
@@ -1,8 +1,7 @@
 import dkist.config as _config
 
 from .fits import AstropyFITSLoader, BaseFITSLoader
-from .reference_collections import (BaseFITSArrayContainer,
-                                    DaskFITSArrayContainer,
+from .reference_collections import (BaseFITSArrayContainer, DaskFITSArrayContainer,
                                     NumpyFITSArrayContainer)
 
 __all__ = ['BaseFITSLoader', 'AstropyFITSLoader', 'BaseFITSArrayContainer',


### PR DESCRIPTION
This uses astropy/astropy#8237 to specify the location of the dkist config file, which we will use for default download locations etc.