### PR TITLE
Initial implementation of gWCS slicing machinery, using ExpressionTree modification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ htmlcov
 .coverage
 MANIFEST
 .ipynb_checkpoints
+.pytest_cache
 
 # Sphinx
 docs/api

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ htmlcov
 MANIFEST
 .ipynb_checkpoints
 .pytest_cache
+.eggs
 
 # Sphinx
 docs/api

--- a/changelog/18.feature.rst
+++ b/changelog/18.feature.rst
@@ -1,0 +1,1 @@
+Add framework for slicing gwcses.

--- a/dkist/conftest.py
+++ b/dkist/conftest.py
@@ -1,57 +1,44 @@
-# This file is used to configure the behavior of pytest when using the Astropy
-# test infrastructure.
+"""
+Shared pytest fixtures.
+"""
 
-from astropy.version import version as astropy_version
-if astropy_version < '3.0':
-    # With older versions of Astropy, we actually need to import the pytest
-    # plugins themselves in order to make them discoverable by pytest.
-    from astropy.tests.pytest_plugins import *
-else:
-    # As of Astropy 3.0, the pytest plugins provided by Astropy are
-    # automatically made available when Astropy is installed. This means it's
-    # not necessary to import them here, but we still need to import global
-    # variables that are used for configuration.
-    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+import pytest
 
-from astropy.tests.helper import enable_deprecations_as_exceptions
+import astropy.units as u
+from astropy.modeling.models import Shift, Multiply, Pix2Sky_AZP, Identity
 
-## Uncomment the following line to treat all DeprecationWarnings as
-## exceptions. For Astropy v2.0 or later, there are 2 additional keywords,
-## as follow (although default should work for most cases).
-## To ignore some packages that produce deprecation warnings on import
-## (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
-## 'setuptools'), add:
-##     modules_to_ignore_on_import=['module_1', 'module_2']
-## To ignore some specific deprecation warning messages for Python version
-## MAJOR.MINOR or later, add:
-##     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
-# enable_deprecations_as_exceptions()
+# gwcs / modeling related fixtures
 
-## Uncomment and customize the following lines to add/remove entries from
-## the list of packages for which version numbers are displayed when running
-## the tests. Making it pass for KeyError is essential in some cases when
-## the package uses other astropy affiliated packages.
-# try:
-#     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-#     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
-#     del PYTEST_HEADER_MODULES['h5py']
-# except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
-#     pass
+@pytest.fixture
+def double_input_flat():
+    return (Identity(1) | Identity(1)) & Identity(1)
 
-## Uncomment the following lines to display the version number of the
-## package rather than the version number of Astropy in the top line when
-## running the tests.
-# import os
-#
-## This is to figure out the package version, rather than
-## using Astropy's
-# try:
-#     from .version import version
-# except ImportError:
-#     version = 'dev'
-#
-# try:
-#     packagename = os.path.basename(os.path.dirname(__file__))
-#     TESTED_VERSIONS[packagename] = version
-# except NameError:   # Needed to support Astropy <= 1.0.0
-#     pass
+
+@pytest.fixture
+def triple_input_flat():
+    return Identity(1) & Identity(1) & Identity(1)
+
+
+@pytest.fixture
+def triple_input_nested():
+    return (Identity(1) | Identity(1) | Identity(1)) & (Identity(1) | Identity(1)) & Identity(1)
+
+
+@pytest.fixture
+def single_non_separable():
+    return Pix2Sky_AZP() | Identity(2)
+
+
+@pytest.fixture
+def double_non_separable():
+    return (Pix2Sky_AZP() | Identity(2)) & Identity(1)
+
+@pytest.fixture
+def spatial_like():
+    crpix1, crpix2 = (100, 100)*u.pix
+    cdelt1, cdelt2 = (10, 10)*(u.arcsec/u.pix)
+
+    shiftu = Shift(-crpix1) & Shift(-crpix2)
+    scale = Multiply(cdelt1) & Multiply(cdelt2)
+
+    return (shiftu | scale | Pix2Sky_AZP()) & Identity(1)

--- a/dkist/utils/model_tools.py
+++ b/dkist/utils/model_tools.py
@@ -1,0 +1,159 @@
+"""
+This is a temporary home for a bunch of code for removing stuff from CompoundModels
+
+I would imagine this will end up in gwcs or maybe even astropy at somepoint.
+"""
+
+from collections import defaultdict
+
+from astropy.modeling import Model, separable
+from astropy.modeling.core import BINARY_OPERATORS, _model_oper
+
+
+OPERATORS = dict((oper, _model_oper(oper)) for oper in BINARY_OPERATORS)
+
+
+def tree_is_separable(tree):
+    """
+    Given a tree, convert it to a `CompoundModel` and then return the
+    separability of the inputs.
+    """
+    return separable.is_separable(tree.evaluate(OPERATORS))
+
+
+def make_tree_input_map(tree):
+    """
+    Construct a mapping of tree to input names.
+
+    This function iterates over all the inputs of a model and determines which
+    side of the tree (left or right) the input corresponds to. It returns a
+    mapping of tree to set of all inputs for that side of the tree (which is
+    also a tree).
+
+    Parameters
+    ----------
+    tree : `astropy.modelling.utils.ExpressionTree`
+        The tree to analyse the inputs of.
+
+    Returns
+    -------
+    tree_input_map : `dict`
+       A mapping of tree to a set of input names.
+    """
+    tree_input_map = defaultdict(set)
+    for i, inp in enumerate(tree.inputs):
+
+        if isinstance(tree.value, Model):
+            # In the situation where the value is a model, we just have the
+            # given input for this tree. Here the tree is the root tree and not
+            # a child of the tree.
+
+            # TODO: Rethink this to use `isleaf`?
+            return {tree: {inp}}
+
+        if tree.value != "&":
+            # Because we are only dealing with extra inputs to the tree we
+            # should only have to parse trees with & as the operator. If we hit
+            # this something has gone wrong.
+            raise Exception("We should never get here.")
+
+        # If this input number is less than the number of inputs in the left
+        # hand side of the tree then the input maps to the LHS of the tree. If
+        # not it maps to the right.
+        if i < len(tree.left.inputs):
+            tree_input_map[tree.left].add(inp)
+        else:
+            tree_input_map[tree.right].add(inp)
+    return tree_input_map
+
+
+def get_tree_with_input(ti_map, input):
+    """
+    Given the input name and a tree input mapping, return the tree which takes
+    the input.
+    """
+    for t, inputs in ti_map.items():
+        if input in inputs:
+            return t
+
+
+def remove_input_frame(tree, inp, remove_coupled_trees=False):
+    """
+    Given a tree, remove the smallest subtree needed to remove the input from the tree.
+
+    This method traverses the expression tree until it finds a tree with only
+    the given input or a tree which has non-separable inputs and takes the
+    given input. It then removes this tree and returns a list of all the other
+    trees in the original tree.
+
+    Parameters
+    ----------
+    tree : `astropy.modelling.utils.ExpressionTree`
+        The tree to analyse the inputs of.
+
+    inp : `str`
+        The name of the input to be removed.
+
+    remove_coupled_trees : (optional) `bool`
+        If `True` remove the subtree that contains input even if it has other
+        non-separable inputs as well. Defaults to `False`.
+
+    Returns
+    -------
+    new_trees : `list`
+        A list of all the trees. Can have the `&` operator applied to
+        reconstruct a `CompoundModel`.
+    """
+    new_trees = []
+    for tree in (tree.left, tree.right):
+        # Generate the input mapping
+        ti_map = make_tree_input_map(tree)
+        # Keep a list of the left and right trees for this tree
+        sub_trees = list(ti_map.keys())
+        # Find if the input we are after is in one of the subtrees for this tree.
+        sub_tree = get_tree_with_input(ti_map, inp)
+        if sub_tree is None:
+            # If we don't have the input, then we save the original tree unmodified.
+            new_trees.append(tree)
+            continue
+
+        # If this subtree only has one input, we drop it and keep all the other one.
+        if len(sub_tree.inputs) == 1:
+            sub_trees.remove(sub_tree)
+            new_trees += sub_trees
+
+        # If we have more than one input, but they are not separable then we
+        # either drop the whole subtree or we keep the original tree
+        # unmodified.
+        sep = tree_is_separable(sub_tree)
+        if all(~sep):
+            if remove_coupled_trees:
+                sub_trees.remove(sub_trees)
+                new_trees += sub_trees
+            else:
+                new_trees.append(tree)
+
+        # TODO: What if we need to recurse down the tree another many levels?!
+        # new_trees += remove_input_frame(sub_tree, inp, remove_coupled_trees)
+
+    return new_trees
+
+
+def re_model_trees(trees):
+    """
+    Given a list of trees return a `CompoundModel` by applying the `&` operator.
+
+    Parameters
+    ----------
+    tree : `list`
+        A list of `astropy.modelling.utils.ExpressionTree` objects.
+
+    Returns
+    -------
+    model : `astropy.modelling.CompoundModel`
+        A model.
+    """
+    left = trees.pop(0).evaluate(OPERATORS)
+    for right in trees:
+        left = left & right.evaluate(OPERATORS)
+    return left

--- a/dkist/utils/tests/test_model_tools.py
+++ b/dkist/utils/tests/test_model_tools.py
@@ -1,0 +1,115 @@
+import pytest
+
+from astropy.modeling.core import Model
+from astropy.modeling.models import Identity, Pix2Sky_AZP
+
+from dkist.utils.model_tools import make_tree_input_map, remove_input_frame, re_model_trees
+
+
+@pytest.fixture
+def double_input_flat():
+    return (Identity(1) | Identity(1)) & Identity(1)
+
+
+@pytest.fixture
+def triple_input_flat():
+    return Identity(1) & Identity(1) & Identity(1)
+
+
+@pytest.fixture
+def triple_input_nested():
+    return (Identity(1) | Identity(1) | Identity(1)) & (Identity(1) | Identity(1)) & Identity(1)
+
+
+@pytest.fixture
+def single_non_separable():
+    return Pix2Sky_AZP() | Identity(2)
+
+
+@pytest.fixture
+def double_non_separable():
+    return (Pix2Sky_AZP() | Identity(2)) & Identity(1)
+
+
+def test_input_map(triple_input_flat):
+    ti_map = make_tree_input_map(triple_input_flat._tree)
+    assert len(ti_map) == 2
+    assert "x00" in list(ti_map.values())[0]
+    assert "x01" in list(ti_map.values())[0]
+    assert "x0" in list(ti_map.values())[1]
+
+
+def test_not_and(single_non_separable):
+    tree = single_non_separable._tree
+    ti = make_tree_input_map(tree)
+    assert len(ti) == 1
+    assert tree in ti.keys()
+
+
+def test_leaf_map(triple_input_nested):
+    tree = triple_input_nested._tree
+    ti_map = make_tree_input_map(tree)
+    assert list(ti_map.keys())[1] is tree.right
+    assert isinstance(list(ti_map.keys())[1].value, Model)
+
+
+def test_remove_non_sep(single_non_separable):
+    tree = single_non_separable._tree
+    trees = remove_input_frame(tree, "x")
+    assert len(trees) == 1
+    assert trees[0] is tree
+
+    trees = remove_input_frame(tree, "x", remove_coupled_trees=True)
+    assert len(trees) == 0
+
+
+def test_remove_non_sep_double(double_non_separable):
+    tree = double_non_separable._tree
+    trees = remove_input_frame(tree, "x")
+    assert len(trees) == 2
+    assert trees[0] is tree.left
+    assert trees[1] is tree.right
+
+    trees = remove_input_frame(tree, "x", remove_coupled_trees=True)
+    assert len(trees) == 1
+    assert trees[0] is tree.right
+
+
+def test_remove_no_input(single_non_separable):
+    tree = single_non_separable._tree
+    trees = remove_input_frame(tree, "x00000")
+    assert len(trees) == 1
+    assert trees[0] is tree
+
+
+def test_remove_frame_flat(triple_input_flat):
+    # x0 is the last input
+    trees = remove_input_frame(triple_input_flat._tree, "x0")
+    assert len(trees) == 1
+    assert len(trees[0].inputs) == 2
+
+
+def test_remove_frame_flat_split(triple_input_flat):
+    # x0 is the last input
+    trees = remove_input_frame(triple_input_flat._tree, "x01")
+    assert len(trees) == 2
+    assert len(trees[0].inputs) == 1
+    assert len(trees[1].inputs) == 1
+
+
+def test_remove_frame_nested(triple_input_nested):
+    # x01 is the second input, therefore splitting the tree
+    trees = remove_input_frame(triple_input_nested._tree, "x01")
+    assert len(trees) == 2
+    assert len(trees[0].inputs) == 1
+    assert len(trees[1].inputs) == 1
+
+
+def test_re_model_nested(triple_input_nested):
+    print(triple_input_nested)
+    # x01 is the second input, therefore splitting the tree
+    trees = remove_input_frame(triple_input_nested._tree, "x01")
+    assert len(trees) == 2
+    model = re_model_trees(trees)
+    assert isinstance(model, Model)
+    assert len(model.inputs) == 2

--- a/dkist/utils/tests/test_model_tools.py
+++ b/dkist/utils/tests/test_model_tools.py
@@ -9,41 +9,7 @@ from astropy.modeling.models import Identity, Pix2Sky_AZP, Shift, Multiply
 
 from dkist.utils.model_tools import make_tree_input_map, remove_input_frame, re_model_trees
 
-
-@pytest.fixture
-def double_input_flat():
-    return (Identity(1) | Identity(1)) & Identity(1)
-
-
-@pytest.fixture
-def triple_input_flat():
-    return Identity(1) & Identity(1) & Identity(1)
-
-
-@pytest.fixture
-def triple_input_nested():
-    return (Identity(1) | Identity(1) | Identity(1)) & (Identity(1) | Identity(1)) & Identity(1)
-
-
-@pytest.fixture
-def single_non_separable():
-    return Pix2Sky_AZP() | Identity(2)
-
-
-@pytest.fixture
-def double_non_separable():
-    return (Pix2Sky_AZP() | Identity(2)) & Identity(1)
-
-@pytest.fixture
-def spatial_like():
-    crpix1, crpix2 = (100, 100)*u.pix
-    cdelt1, cdelt2 = (10, 10)*(u.arcsec/u.pix)
-
-    shiftu = Shift(-crpix1) & Shift(-crpix2)
-    scale = Multiply(cdelt1) & Multiply(cdelt2)
-
-    return (shiftu | scale | Pix2Sky_AZP()) & Identity(1)
-
+## Fixtures used in this file are defined in conftest.py
 
 def test_input_map(triple_input_flat):
     ti_map = make_tree_input_map(triple_input_flat._tree)

--- a/dkist/wcs/__init__.py
+++ b/dkist/wcs/__init__.py
@@ -1,0 +1,3 @@
+"""
+A submodule for general helpers with world coordinate systems.
+"""

--- a/dkist/wcs/slicer.py
+++ b/dkist/wcs/slicer.py
@@ -137,17 +137,27 @@ class GWCSSlicer:
         """
         iframe = self.gwcs.input_frame
         assert isinstance(iframe, cf.CoordinateFrame) and not isinstance(iframe, cf.CompositeFrame)
+        assert iframe._reference_position is None and iframe._reference_frame is None
+
         mods = ("axes_type", "unit", "axes_names")
-        copys = ("name,")
+        copys = ("name",)
 
         attrs = {}
         for ax in axes:
             for m in mods:
                 n = list(getattr(iframe, m))
-                new = n.pop(ax)
-                attrs[m] = new
+                n.pop(ax)
+                attrs[m] = tuple(n)
+
+        for at in copys:
+            attrs[at] = getattr(iframe, at)
+
         attrs["naxes"] = iframe.naxes - len(axes)
 
+        attrs["axes_order"] = tuple(range(attrs["naxes"]))
+
+        r = type(iframe)(**attrs)
+        return r
 
 
     def _list_to_compound(self, models):
@@ -228,7 +238,7 @@ class GWCSSlicer:
         new_in_frame = self.gwcs.input_frame
         new_out_frame = self.gwcs.output_frame
         if axes_to_drop:
-            # new_in_frame = self._new_input_frame(axes_to_drop)
+            new_in_frame = self._new_input_frame(axes_to_drop)
             new_out_frame = self._new_output_frame(axes_to_drop)
 
         # Update the gwcs

--- a/dkist/wcs/slicer.py
+++ b/dkist/wcs/slicer.py
@@ -161,6 +161,10 @@ class GWCSSlicer:
 
         return item
 
+    def _input_units(self):
+        ft = self.gwcs.forward_transform
+        return {inp: ft.input_units.get(ft.inputs[inp], 1) for inp in range(ft.n_inputs)}
+
     def __getitem__(self, item):
         """
         Once the item is sanitized, we fix the parameter if the item is an integer,
@@ -178,14 +182,15 @@ class GWCSSlicer:
         # We always add a model to prepend list so that we maintain consistency
         # with the number of axes. If prepend is entirely identity models, it
         # is not used.
+        input_units = self._input_units()
         for i, ax in enumerate(item):
             if isinstance(ax, int):
                 if self.separable[i]:
                     axes_to_drop.append(i)
                 else:
-                    prepend.append(FixedParameter(ax*u.pix))
+                    prepend.append(FixedParameter(ax*input_units[i]))
             elif ax.start:
-                prepend.append(Shift(ax.start*u.pix))
+                prepend.append(Shift(ax.start*input_units[i]))
             else:
                 prepend.append(Identity(1))
 

--- a/dkist/wcs/slicer.py
+++ b/dkist/wcs/slicer.py
@@ -1,0 +1,210 @@
+"""
+This module contains tools for slicing gwcs objects.
+"""
+
+from astropy.modeling import Model, Parameter
+from astropy.modeling.models import Identity
+
+
+__all__ = ['GWCSSlicer', 'FixedParameter']
+
+
+class FixedParameter(Model):
+    """
+    A Model that injects a parameter as an output.
+
+    The inverse of this model does nothing (is the ``Identity`` model), as the
+    parameter is only defined in the input direction.
+    """
+    value = Parameter()
+    inputs = tuple()
+    outputs = ('x',)
+
+    @staticmethod
+    def evaluate(value):
+        return value[0]
+
+    @property
+    def inverse(self):
+        return Identity(1)
+
+
+class GWCSSlicer:
+    """
+    A class which will slice a gwcs object when its ``__getitem__`` method is called.
+
+    Parameters
+    ----------
+    gwcs : `gwcs.wcs.WCS`
+        A gwcs model to be sliced.
+
+    copy : `bool`
+        A flag to determine if the input gwcs should be copied.
+
+    Examples
+    --------
+
+    >>> myslicedgwcs = Slicer(mygwcs)[10, : , 0]
+    """
+    def __init__(self, gwcs, copy=False):
+        if copy:
+            gwcs = copy.deepcopy(gwcs)
+        self.gwcs = gwcs
+        self.naxis = wcsobj.forward_transform.n_inputs
+        self.separable = separable.is_separable(self.gwcs.forward_transform)
+        self._compare_frames_separable()
+
+    def _get_frames(self):
+        """
+        Return a list of frames which comprise the output frame.
+        """
+        if hasattr(self.gwcs.output_frame, "frames"):
+            frames = self.gwcs.output_frame.frames
+        else:
+            frames = (self.gwcs.output_frame,)
+        return frames
+
+    def _get_coupled_axes(self):
+        """
+        Return the a list of axes number tuples which are coupled by sharing a frame.
+        """
+        frames = self._get_frames()
+
+        coupled_axes = []
+        for frame in frames:
+            if len(frame.axes_order) > 1:
+                coupled_axes.append(frame.axes_order)
+
+        return coupled_axes
+
+    def _compare_frames_separable(self):
+        """
+        Validate that the coupled (via frames) and separable (via the model)
+        information matches.
+        """
+        coupled_axes = self._get_coupled_axes()
+        for pair in coupled_axes:
+            for ax in pair:
+                if self.separable[ax]:
+                    raise ValueError("Panic")
+
+    def _get_axes_map(self, frames):
+        """
+        Map the number of the axes to its frame.
+        """
+        axes_map = {}
+        for frame in frames:
+            for ax in frame.axes_order:
+                axes_map[ax] = frame
+
+        return axes_map
+
+    def _new_output_frame(self, axes):
+        """
+        remove the frames for all axes and return a new output frame
+        """
+        frames = self._get_frames()
+        axes_map = self._get_axes_map(frames)
+
+        frames = list(frames)
+        for axis in axes:
+            drop_frame = axes_map[axis]
+            frames.remove(drop_frame)
+
+        if len(frames) == 1:
+            return frames[0]
+        else:
+            return cf.CompositeFrame(frames, name=self.gwcs.output_frame.name)
+
+    def _sanitize(self, item):
+        """
+        Convert the item into a list of items. Which is the same length
+        as the number of axes in the input frame.
+
+        The output list will either contain a slice object for a range
+        (if the slice.start is None then no operation is done on that axis)
+        or an integer if the value of the axis is to be fixed.
+        """
+        if not isinstance(item, (tuple, list)): # We just have a single int
+            item = (item,)
+
+        item = list(item)
+
+        for i in range(self.naxis):
+            if i < len(item):
+                ax = item[i]
+                if isinstance(ax, slice):
+                    if ax.step:
+                        raise ValueError("can not change step yet")
+                elif not isinstance(ax, int):
+                    raise ValueError("Only integer or range slices are accepted.")
+            else:
+                item.append(slice(None))
+
+        return item
+
+    def _list_to_compound(self, models):
+        """
+        Convert a list of models into a compound model using the ``&`` operator.
+        """
+        # Convert the list of models into a CompoundModel
+        comp_m = models[0]
+        for m in models[1:]:
+            comp_m = comp_m & m
+        return comp_m
+
+    def __getitem__(self, item):
+        """
+        Once the item is sanitized, we fix the parameter if the item is an integer,
+        shift if the start is set on the slice or
+        do nothing to the axis otherwise.
+        """
+        item = self._sanitize(item)
+
+        prepend = []
+        append = []
+        axes_to_drop = []
+
+        # Iterate over all the axes and keep a list of models to append or
+        # prepend to the transform, and a list of axes to remove from the wcs
+        # completely.
+
+        # We always add a model to prepend and append lists so that we maintain
+        # consistency with the number of axes. If prepend or append is entirely
+        # identity models, they are not used.
+        for i, ax in enumerate(item):
+            if isinstance(ax, int):
+                if self.separable[i]:
+                    axes_to_drop.append(i)
+                else:
+                    prepend.append(FixedParameter(ax*u.pix))
+                    append.append(Identity(1))
+            elif ax.start:
+                prepend.append(Shift(ax.start*u.pix))
+                append.append(Identity(1))
+            else:
+                prepend.append(Identity(1))
+                append.append(Identity(1))
+
+        model = self.gwcs.forward_transform
+        for drop_ax in axes_to_drop:
+            inp = model._tree.inputs[drop_ax]
+            trees = remove_input_frame(model._tree, inp)
+            model = re_model_trees(trees)
+
+        if not all([isinstance(a, Identity) for a in prepend]):
+            model = self._list_to_compound(prepend) | model
+
+        if not all([isinstance(a, Identity) for a in append]):
+            model = model | self._list_to_compound(append)
+
+        new_in_frame = self.gwcs.input_frame
+        new_out_frame = self.gwcs.output_frame
+        if axes_to_drop:
+            # new_in_frame = self._new_input_frame(axes_to_drop)
+            new_out_frame = self._new_output_frame(axes_to_drop)
+
+        # Update the gwcs
+        self.gwcs._initialize_wcs(model, new_in_frame, new_out_frame)
+
+        return self.gwcs

--- a/dkist/wcs/tests/test_slicer.py
+++ b/dkist/wcs/tests/test_slicer.py
@@ -1,0 +1,131 @@
+import pytest
+
+import astropy.units as u
+from astropy.modeling.models import Identity
+
+from sunpy.coordinates.frames import Helioprojective
+
+from gwcs import WCS
+import gwcs.coordinate_frames as cf
+
+from dkist.wcs.slicer import FixedParameter, GWCSSlicer
+from dkist.conftest import spatial_like
+
+def test_fixed_parameter():
+    fp = FixedParameter(1)
+    assert fp() == 1
+    assert fp.n_inputs == 0
+    assert fp.n_outputs == 1
+
+def test_fixed_parameter_inverse():
+    fp = FixedParameter(1)
+    inv = fp.inverse
+    assert isinstance(inv, Identity)
+    assert inv.n_inputs == 1
+
+
+## Some fixtures used in this file are defined in conftest.py
+
+@pytest.fixture
+def gwcs_3d():
+    detector_frame = cf.CoordinateFrame(name="detector",
+                                        naxes=3,
+                                        axes_order=(0,1,2),
+                                        axes_type=("pixel", "pixel", "pixel"),
+                                        axes_names=("x", "y", "z"),
+                                        unit=(u.pix, u.pix, u.pix))
+
+    sky_frame = cf.CelestialFrame(reference_frame=Helioprojective(), name='hpc')
+    spec_frame = cf.SpectralFrame(name="spectral", axes_order=(2,), unit=u.nm)
+    out_frame = cf.CompositeFrame(frames=(sky_frame, spec_frame))
+
+    return WCS(forward_transform=spatial_like(), input_frame=detector_frame, output_frame=out_frame)
+
+@pytest.fixture
+def gwcs_1d():
+    detector_frame = cf.CoordinateFrame(name="detector",
+                                        naxes=1,
+                                        axes_order=(0,),
+                                        axes_type=("pixel"),
+                                        axes_names=("x"),
+                                        unit=(u.pix))
+
+    spec_frame = cf.SpectralFrame(name="spectral", axes_order=(2,), unit=u.nm)
+
+    return WCS(forward_transform=Identity(1), input_frame=detector_frame, output_frame=spec_frame)
+
+
+@pytest.fixture
+def slicer_1d():
+    return GWCSSlicer(gwcs_1d())
+
+
+@pytest.fixture
+def slicer_3d():
+    return GWCSSlicer(gwcs_3d())
+
+
+def test_slicer_init(gwcs_3d, gwcs_1d):
+    for gwcs in (gwcs_1d, gwcs_3d):
+        slc = GWCSSlicer(gwcs)
+        assert isinstance(slc, GWCSSlicer)
+        assert slc.gwcs is gwcs
+
+        slc = GWCSSlicer(gwcs, copy=True)
+        assert isinstance(slc, GWCSSlicer)
+        assert slc.gwcs is not gwcs
+
+
+def test_get_axes_map(slicer_3d):
+    amap = slicer_3d._get_axes_map(slicer_3d._get_frames())
+    assert len(amap) == 3
+    assert amap[0] is amap[1]
+    assert amap[2] is not amap[1]
+    assert amap[2] is not amap[0]
+
+def test_new_output_frame(slicer_1d, slicer_3d):
+    assert slicer_1d._new_output_frame(tuple()) is slicer_1d.gwcs.output_frame
+    assert slicer_3d._new_output_frame(tuple()) is not slicer_1d.gwcs.output_frame
+
+    new_frame = slicer_3d._new_output_frame(tuple())
+    assert isinstance(new_frame, cf.CompositeFrame)
+    assert len(new_frame.frames) == 2
+
+    new_frame = slicer_3d._new_output_frame((2,))
+    assert isinstance(new_frame, cf.CoordinateFrame)
+
+
+def test_simple_slices(slicer_3d):
+    sl = slicer_3d[:,:,:]
+    assert sl is slicer_3d.gwcs
+
+def test_simple_slices2(slicer_3d):
+    sl2 = slicer_3d[:,:,0]
+    assert sl2.forward_transform.n_inputs == 2
+    assert isinstance(sl2.output_frame, cf.CoordinateFrame)
+
+def test_simple_slices3(slicer_3d):
+    sl = slicer_3d[:,10,:]
+    assert sl.forward_transform.n_inputs == 2
+    assert sl.forward_transform.n_outputs == 3
+    assert isinstance(sl.output_frame, cf.CompositeFrame)
+
+def test_simple_slices4(slicer_3d):
+    sl = slicer_3d[10]
+    assert sl.forward_transform.n_inputs == 2
+    assert sl.forward_transform.n_outputs == 3
+    assert isinstance(sl.output_frame, cf.CompositeFrame)
+
+def test_simple_slices5(slicer_3d):
+    sl = slicer_3d[10:]
+    assert sl.forward_transform.n_inputs == 3
+    assert sl.forward_transform.n_outputs == 3
+    assert isinstance(sl.output_frame, cf.CompositeFrame)
+
+def test_error_step(slicer_3d):
+    with pytest.raises(ValueError):
+        sl = slicer_3d[::2]
+
+def test_error_type(slicer_3d):
+    with pytest.raises(ValueError):
+        sl = slicer_3d["laksjdkslja"]

--- a/dkist/wcs/tests/test_slicer.py
+++ b/dkist/wcs/tests/test_slicer.py
@@ -129,3 +129,8 @@ def test_error_step(slicer_3d):
 def test_error_type(slicer_3d):
     with pytest.raises(ValueError):
         sl = slicer_3d["laksjdkslja"]
+
+def test_roundtrip(slicer_3d):
+    wcs = slicer_3d[10:, 10, 10]
+    w = wcs(10*u.pix, with_units=True)
+    wcs.invert(w, with_units=True)

--- a/dkist/wcs/tests/test_slicer.py
+++ b/dkist/wcs/tests/test_slicer.py
@@ -1,6 +1,7 @@
 import pytest
 
 import astropy.units as u
+from astropy.coordinates import SkyCoord
 from astropy.modeling.models import Identity
 
 from sunpy.coordinates.frames import Helioprojective
@@ -130,7 +131,10 @@ def test_error_type(slicer_3d):
     with pytest.raises(ValueError):
         sl = slicer_3d["laksjdkslja"]
 
+
 def test_roundtrip(slicer_3d):
     wcs = slicer_3d[10:, 10, 10]
     w = wcs(10*u.pix, with_units=True)
-    wcs.invert(w, with_units=True)
+    assert isinstance(w, SkyCoord)
+    p = wcs.invert(w, with_units=True)
+    assert len(p) == 2


### PR DESCRIPTION
This code drops branches from ExpressionTrees to remove inputs (and their corresponding outputs) from the model. The idea is to use this when slicing the gwcs object.