### PR TITLE
Improve performance of Dask array construction

### DIFF
--- a/dkist/io/array_containers.py
+++ b/dkist/io/array_containers.py
@@ -70,9 +70,10 @@ class ExternalArrayReferenceCollection:
         Construct a collection from a (nested) iterable of
         `asdf.ExternalArrayReference` objects.
         """
-        shape = ears[0].shape
-        dtype = ears[0].dtype
-        target = ears[0].target
+        array_ears = np.asarray(ears, dtype=object)
+        shape = array_ears.flat[0].shape
+        dtype = array_ears.flat[0].dtype
+        target = array_ears.flat[0].target
 
         for i, ele in enumerate(ears):
             uris = cls._validate_homogenaity(shape, target, dtype, ears)

--- a/dkist/io/tests/test_collections.py
+++ b/dkist/io/tests/test_collections.py
@@ -94,3 +94,22 @@ def test_collection_getitem(tmpdir, earcollection):
     assert isinstance(earcollection[1], ExternalArrayReferenceCollection)
     assert len(earcollection[0]) == len(earcollection[1]) == 1
     assert earcollection[0:2] == earcollection
+
+
+@pytest.fixture
+def large_EARCollection():
+    ear = asdf.ExternalArrayReference("efz20040301.000010_s.fits",
+                                      0,
+                                      "float64",
+                                      (128, 128))
+
+    ears = [[[ear] * 128 ] * 32] * 4
+
+    return DaskFITSArrayContainer.from_external_array_references(ears, loader=AstropyFITSLoader)
+
+
+def test_construct_large_array(benchmark, large_EARCollection):
+    arr = benchmark(lambda: large_EARCollection.array)
+
+    assert arr.shape == (4, 32, 128, 128, 128)
+    assert arr.chunksize == (1, 1, 1, 128, 128)


### PR DESCRIPTION
The load only happens once per asdf file read, but we should still try and make it as efficient as possible.