### PR TITLE
Refactor file handling

### DIFF
--- a/dkist/conftest.py
+++ b/dkist/conftest.py
@@ -11,7 +11,7 @@ from astropy.time import Time
 from sunpy.coordinates.frames import Helioprojective
 
 from dkist.dataset import Dataset
-from dkist.io import AstropyFITSLoader, DaskFITSArrayContainer
+from dkist.io import AstropyFITSLoader, DaskFITSArrayCollection
 
 
 @pytest.fixture
@@ -179,7 +179,7 @@ def dataset(array, identity_gwcs):
     assert ds.data is array
     assert ds.wcs is identity_gwcs
 
-    ds._array_container = DaskFITSArrayContainer(['test1.fits'], 0, 'float', array.shape,
+    ds._array_container = DaskFITSArrayCollection(['test1.fits'], 0, 'float', array.shape,
                                                  loader=AstropyFITSLoader)
 
     return ds

--- a/dkist/dataset/dataset.py
+++ b/dkist/dataset/dataset.py
@@ -10,7 +10,7 @@ import gwcs
 from astropy.wcs.wcsapi.wrappers import SlicedLowLevelWCS
 from ndcube.ndcube import NDCube
 
-from dkist.io import DaskFITSArrayContainer
+from dkist.io import DaskFITSArrayCollection
 from dkist.utils.globus import (DKIST_DATA_CENTRE_DATASET_PATH, DKIST_DATA_CENTRE_ENDPOINT_ID,
                                 start_transfer_from_file_list, watch_transfer_progress)
 from dkist.utils.globus.endpoints import get_local_endpoint_id, get_transfer_client
@@ -124,7 +124,8 @@ class Dataset(NDCube):
         if self._array_container is None:
             return []
         else:
-            return self._array_container.filenames
+            return self._array_container.get_filenames()
+
 
     """
     Dataset loading and saving routines.
@@ -233,8 +234,8 @@ class Dataset(NDCube):
         # The real solution to this is to use the database.
         local_destination = destination_path.relative_to("/").expanduser()
         old_ac = self._array_container
-        self._array_container = DaskFITSArrayContainer.from_external_array_references(
+        self._array_container = DaskFITSArrayCollection.from_external_array_references(
             old_ac.external_array_references,
             loader=old_ac._loader,
             basepath=local_destination)
-        self._data = self._array_container.array
+        self._data = self._array_container.get_array()

--- a/dkist/dataset/filemanager.py
+++ b/dkist/dataset/filemanager.py
@@ -1,0 +1,71 @@
+import os
+from typing import Any
+from pathlib import Path
+
+import numpy as np
+
+from dkist.io.array_containers import BaseFITSArrayCollection
+
+try:
+    from numpy.typing import ArrayLike
+except ImportError:
+    ArrayLike = Any
+
+
+class FileManager:
+    """
+    Manages the set of files which back a DKIST `~.Dataset`.
+    """
+
+    def __init__(self, array_collection, file_slice=None):
+        self._array_collection = array_collection
+        self._file_slice = None
+
+    @property
+    def data(self) -> ArrayLike:
+        """
+        The array object generated from the files.
+        """
+        return self.array_collection.get_array(self._file_slice)
+
+    @property
+    def array_collection(self) -> BaseFITSArrayCollection:
+        """
+        The `~.BaseFITSArrayCollection object which loads arrays from the files.
+        """
+        return self._array_collection
+
+    @property
+    def base_path(self) -> os.PathLike:
+        """
+        Root path for all the FITS files.
+        """
+        return self.array_collection.loader.keywords["base_path"]
+
+    @base_path.setter
+    def base_path(self, base_path: os.PathLike):
+        """
+        Set the base path.
+
+        This triggers a rebuild in the array collection.
+        """
+        kwargs = self.array_collection.loader.keywords.copy()
+        kwargs["base_path"] = Path(base_path)
+        self.array_collection.set_loader_kwargs(**kwargs)
+
+    def __getitem__(self, item):
+        return type(self)(self.array_collection, item)
+
+    # def sliced_output_shape(self, aslice):
+    #     return np.broadcast_to(1, self.output_shape)[aslice].shape
+
+    # def array_slice_to_reference_slice(self, aslice):
+    #     """
+    #     Convert a slice for the reconstructed array to a slice fort the reference_array.
+    #     """
+    #     aslice = list(sanitize_slices(aslice, len(self.output_shape)))
+    #     if self.shape[0] == 1:
+    #         # Insert a blank slice for the removed dimension
+    #         aslice.insert(len(self.shape) - 1, slice(None))
+    #     aslice = aslice[len(self.shape):]
+    #     return tuple(aslice)

--- a/dkist/dataset/filemanager.py
+++ b/dkist/dataset/filemanager.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 import numpy as np
 
-from dkist.io.array_containers import BaseFITSArrayCollection
+from astropy.wcs.wcsapi.wrappers.sliced_wcs import sanitize_slices, combine_slices
+
+from dkist.io.array_collections import BaseFITSArrayCollection
+from dkist.utils.globus import (DKIST_DATA_CENTRE_DATASET_PATH, DKIST_DATA_CENTRE_ENDPOINT_ID,
+                                start_transfer_from_file_list, watch_transfer_progress)
+from dkist.utils.globus.endpoints import get_local_endpoint_id, get_transfer_client
 
 try:
     from numpy.typing import ArrayLike
@@ -53,19 +58,74 @@ class FileManager:
         kwargs["base_path"] = Path(base_path)
         self.array_collection.set_loader_kwargs(**kwargs)
 
+    @property
+    def filenames(self):
+        return self.array_collection.get_filenames(self._file_slice)
+
     def __getitem__(self, item):
+        item = sanitize_slices(item, self.array_collection.reference_array.ndim)
+        if self._file_slice is not None:
+            item = tuple(combine_slices(s1, s2) for s1, s2 in zip(item, self._file_slice))
         return type(self)(self.array_collection, item)
 
-    # def sliced_output_shape(self, aslice):
-    #     return np.broadcast_to(1, self.output_shape)[aslice].shape
+    def _get_array_item(self, item):
+        return self[self.array_slice_to_reference_slice(item)]
 
-    # def array_slice_to_reference_slice(self, aslice):
-    #     """
-    #     Convert a slice for the reconstructed array to a slice fort the reference_array.
-    #     """
-    #     aslice = list(sanitize_slices(aslice, len(self.output_shape)))
-    #     if self.shape[0] == 1:
-    #         # Insert a blank slice for the removed dimension
-    #         aslice.insert(len(self.shape) - 1, slice(None))
-    #     aslice = aslice[len(self.shape):]
-    #     return tuple(aslice)
+    def array_slice_to_reference_slice(self, aslice):
+        """
+        Convert a slice for the reconstructed array to a slice fort the reference_array.
+        """
+        output_shape = self.array_collection.get_output_shape(self._file_slice)
+        shape = self.array_collection.shape
+        aslice = list(sanitize_slices(aslice, len(output_shape)))
+        if shape[0] == 1:
+            # Insert a blank slice for the removed dimension
+            aslice.insert(len(shape) - 1, slice(None))
+        aslice = aslice[len(shape):]
+        return tuple(aslice)
+
+    def download(self, path="/~/", destination_endpoint=None, progress=True):
+        """
+        Start a Globus file transfer for all files in this Dataset.
+
+        Parameters
+        ----------
+        path : `pathlib.Path` or `str`, optional
+            The path to save the data in, must be accessible by the Globus
+            endpoint.
+
+        destination_endpoint : `str`, optional
+            A unique specifier for a Globus endpoint. If `None` a local
+            endpoint will be used if it can be found, otherwise an error will
+            be raised. See `~dkist.utils.globus.get_endpoint_id` for valid
+            endpoint specifiers.
+
+        progress : `bool`, optional
+           If `True` status information and a progress bar will be displayed
+           while waiting for the transfer to complete.
+        """
+
+        base_path = Path(DKIST_DATA_CENTRE_DATASET_PATH.format(**self.meta))
+        # TODO: Default path to the config file
+        destination_path = Path(path) / self.meta['primaryProposalId'] / self.meta['datasetId']
+
+        file_list = [base_path / fn for fn in self.filenames]
+        file_list.append(Path("/") / self.meta['bucket'] / self.meta['asdfObjectKey'])
+
+        if not destination_endpoint:
+            destination_endpoint = get_local_endpoint_id()
+
+        task_id = start_transfer_from_file_list(DKIST_DATA_CENTRE_ENDPOINT_ID,
+                                                destination_endpoint, destination_path,
+                                                file_list)
+
+        tc = get_transfer_client()
+        if progress:
+            watch_transfer_progress(task_id, tc, initial_n=len(file_list))
+        else:
+            tc.task_wait(task_id, timeout=1e6)
+
+        # TODO: Work out if the destination is actually local or not.
+        local_destination = destination_path.relative_to("/").expanduser()
+        self.base_path = local_destination
+

--- a/dkist/dataset/tests/test_dataset.py
+++ b/dkist/dataset/tests/test_dataset.py
@@ -11,7 +11,7 @@ from astropy.tests.helper import assert_quantity_allclose
 
 from dkist.data.test import rootdir
 from dkist.dataset import Dataset
-from dkist.io.array_containers import BaseFITSArrayContainer
+from dkist.io.array_containers import BaseFITSArrayCollection
 from dkist.utils.globus import DKIST_DATA_CENTRE_DATASET_PATH, DKIST_DATA_CENTRE_ENDPOINT_ID
 
 
@@ -92,11 +92,11 @@ def test_array_container():
     with pytest.raises(AttributeError):
         dataset.array_container = 10
 
-    assert len(dataset.array_container.filenames) == 11
+    assert len(dataset.array_container.get_filenames()) == 11
     assert len(dataset.filenames) == 11
 
-    assert isinstance(dataset[5]._array_container, BaseFITSArrayContainer)
-    assert len(dataset[5].filenames) == 1
+    # assert isinstance(dataset[5]._array_container, BaseFITSArrayCollection)
+    # assert len(dataset[5].filenames) == 1
 
 
 def test_no_filenames(dataset_3d):

--- a/dkist/dataset/tests/test_dataset.py
+++ b/dkist/dataset/tests/test_dataset.py
@@ -11,7 +11,7 @@ from astropy.tests.helper import assert_quantity_allclose
 
 from dkist.data.test import rootdir
 from dkist.dataset import Dataset
-from dkist.io.array_containers import BaseFITSArrayCollection
+from dkist.io.array_collections import BaseFITSArrayCollection
 from dkist.utils.globus import DKIST_DATA_CENTRE_DATASET_PATH, DKIST_DATA_CENTRE_ENDPOINT_ID
 
 
@@ -86,17 +86,13 @@ def test_crop_few_slices(dataset_4d):
     assert sds.wcs.world_n_dim == 2
 
 
-def test_array_container():
+def test_files():
     dataset = Dataset.from_directory(os.path.join(rootdir, 'EIT'))
-    assert dataset.array_container is dataset._array_container
     with pytest.raises(AttributeError):
-        dataset.array_container = 10
+        dataset.files = 10
 
-    assert len(dataset.array_container.get_filenames()) == 11
-    assert len(dataset.filenames) == 11
-
-    # assert isinstance(dataset[5]._array_container, BaseFITSArrayCollection)
-    # assert len(dataset[5].filenames) == 1
+    assert len(dataset.files.filenames) == 11
+    assert len(dataset[5].files.filenames) == 1
 
 
 def test_no_filenames(dataset_3d):

--- a/dkist/io/__init__.py
+++ b/dkist/io/__init__.py
@@ -1,6 +1,6 @@
 import dkist.config as _config
 
-from .array_containers import (BaseFITSArrayCollection, DaskFITSArrayCollection,
+from .array_collections import (BaseFITSArrayCollection, DaskFITSArrayCollection,
                                NumpyFITSArrayCollection)
 from .loaders import AstropyFITSLoader, BaseFITSLoader
 

--- a/dkist/io/__init__.py
+++ b/dkist/io/__init__.py
@@ -1,11 +1,11 @@
 import dkist.config as _config
 
-from .array_containers import (BaseFITSArrayContainer, DaskFITSArrayContainer,
-                               NumpyFITSArrayContainer)
+from .array_containers import (BaseFITSArrayCollection, DaskFITSArrayCollection,
+                               NumpyFITSArrayCollection)
 from .loaders import AstropyFITSLoader, BaseFITSLoader
 
-__all__ = ['BaseFITSLoader', 'AstropyFITSLoader', 'BaseFITSArrayContainer',
-           'NumpyFITSArrayContainer', 'DaskFITSArrayContainer', 'conf']
+__all__ = ['BaseFITSLoader', 'AstropyFITSLoader', 'BaseFITSArrayCollection',
+           'NumpyFITSArrayCollection', 'DaskFITSArrayCollection', 'conf']
 
 
 class Conf(_config.ConfigNamespace):

--- a/dkist/io/array_collections.py
+++ b/dkist/io/array_collections.py
@@ -16,7 +16,7 @@ from sunpy.util.decorators import add_common_docstring
 from dkist.io.loaders import AstropyFITSLoader
 from dkist.io.utils import SliceCache
 
-__all__ = ['BaseFITSArrayContainer', 'NumpyFITSArrayContainer', 'DaskFITSArrayContainer']
+__all__ = ['BaseFITSArrayCollection', 'NumpyFITSArrayCollection', 'DaskFITSArrayCollection']
 
 
 # This class should probably live in asdf, and there are PRs open to add it.
@@ -253,7 +253,7 @@ class BaseFITSArrayCollection(ExternalArrayReferenceCollection, metaclass=abc.AB
 
     def get_filenames(self, aslice=None):
         """
-        Return a list of file names referenced by this Array Container.
+        Return a list of file names referenced by this Array Collection.
         """
         reference_array = self.reference_array[aslice]
         return [ear.fileuri for ear in reference_array.flat]
@@ -318,7 +318,7 @@ def stack_loader_array(loader_array):
 
     Parameters
     ----------
-    loader_array : `dkist.io.reference_collections.BaseFITSArrayContainer`
+    loader_array : `dkist.io.reference_collections.BaseFITSArrayCollection`
 
     Returns
     -------

--- a/dkist/io/array_containers.py
+++ b/dkist/io/array_containers.py
@@ -10,9 +10,11 @@ import dask.array as da
 import numpy as np
 
 from asdf.tags.core.external_reference import ExternalArrayReference
+from astropy.wcs.wcsapi.wrappers.sliced_wcs import sanitize_slices
 from sunpy.util.decorators import add_common_docstring
 
 from dkist.io.loaders import AstropyFITSLoader
+from dkist.io.utils import SliceCache
 
 __all__ = ['BaseFITSArrayContainer', 'NumpyFITSArrayContainer', 'DaskFITSArrayContainer']
 
@@ -97,12 +99,6 @@ class ExternalArrayReferenceCollection:
         """
         return self._to_ears(self.fileuris)
 
-    def __getitem__(self, item):
-        uris = np.array(self.fileuris)[item].tolist()
-        if isinstance(uris, str):
-            uris = [uris]
-        return type(self)(uris, self.target, self.dtype, self.shape)
-
     def __len__(self):
         return len(self.fileuris)
 
@@ -154,7 +150,7 @@ common_parameters = """
 """
 
 @add_common_docstring(append=common_parameters)
-class BaseFITSArrayContainer(ExternalArrayReferenceCollection, metaclass=abc.ABCMeta):
+class BaseFITSArrayCollection(ExternalArrayReferenceCollection, metaclass=abc.ABCMeta):
     """
     A collection of references to homogenous FITS arrays.
     """
@@ -165,97 +161,153 @@ class BaseFITSArrayContainer(ExternalArrayReferenceCollection, metaclass=abc.ABC
         filepath = Path((ctx.uri or ".").replace("file:", ""))
         base_path = filepath.parent
 
-        # TODO: The choice of Dask and Astropy here should be in a config somewhere.
-        array_container = DaskFITSArrayContainer(node['fileuris'],
-                                                 node['target'],
-                                                 node['datatype'],
-                                                 node['shape'],
-                                                 loader=AstropyFITSLoader,
-                                                 basepath=base_path)
+        array_container = cls(node['fileuris'],
+                              node['target'],
+                              node['datatype'],
+                              node['shape'],
+                              loader=AstropyFITSLoader,
+                              basepath=base_path)
         return array_container
 
 
     def __init__(self, fileuris, target, dtype, shape, *, loader, **kwargs):
         super().__init__(fileuris, target, dtype, shape)
-        reference_array = np.asarray(self.external_array_references, dtype=object)
+        self.reference_array = np.asarray(self.external_array_references, dtype=object)
 
-        # If the first dimension is one we are going to squash it.
+        self.full_output_shape = self.get_output_shape()
+
+        # Initialise internal attributes
+        self._loader = None
+        self._loader_array_cache = None
+        self._array_cache = SliceCache()
+
+        # Store the loader and the kwargs as a partial function.
+        self.loader_class = loader
+        self.loader = partial(loader, **kwargs)
+
+    def get_output_shape(self, aslice=None):
+        ref_array = self.reference_array
+        if aslice is not None:
+            ref_array = ref_array[aslice]
+
+        # If the first dimension of the external arrays are one we are going to
+        # squash that dimension.
         reference_shape = self.shape
         if reference_shape[0] == 1:
             reference_shape = reference_shape[1:]
-        if len(reference_array) == 1:
-            self.output_shape = reference_shape
+
+        # If for some reason we have a collection of one, our output shape is
+        # the (squashed) array shape.
+        if self.reference_array.size == 1:
+            output_shape = reference_shape
         else:
-            self.output_shape = tuple(list(reference_array.shape) + list(reference_shape))
+            output_shape = tuple(list(ref_array.shape) + list(reference_shape))
 
-        loader_array = np.empty_like(reference_array, dtype=object)
-        for i, ele in enumerate(reference_array.flat):
-            loader_array.flat[i] = loader(ele, **kwargs)
-
-        self.loader_array = loader_array
-        self._loader = partial(loader, **kwargs)
-
-    def __getitem__(self, item):
-        # Apply slice as array, but then back to nested lists
-        uris = np.array(self.fileuris)[item].tolist()
-        if isinstance(uris, str):
-            uris = [uris]
-        # Override this method to set loader
-        return type(self)(uris, self.target, self.dtype, self.shape, loader=self._loader)
+        return output_shape
 
     @property
-    def filenames(self):
+    def loader(self):
+        """
+        Partial function version of the loader class with kwargs set.
+        """
+        return self._loader
+
+    @loader.setter
+    def loader(self, loader):
+        """
+        Update the loader, clear the cache.
+        """
+        self._loader = loader
+        self._loader_array_cache = None
+        self._array_cache = SliceCache()
+
+    def set_loader_kwargs(self, **kwargs):
+        """
+        Set new kwargs for the loader.
+        """
+        self.loader = partial(self.loader_class, **kwargs)
+
+    @property
+    def loader_array(self):
+        """
+        A numpy array of correct shape with instantiated loader objects.
+        """
+        if self._loader_array_cache is None:
+            loader_array = np.empty_like(self.reference_array, dtype=object)
+            for i, ele in enumerate(self.reference_array.flat):
+                loader_array.flat[i] = self._loader(ele)
+            self._loader_array_cache = loader_array
+
+        return self._loader_array_cache
+
+    def _parse_aslice(self, aslice):
+        """
+        Helper to set a default aslice
+        """
+        if aslice is None:
+            aslice = tuple([slice(None)] * self.reference_array.ndim)
+
+        if not isinstance(aslice, tuple):
+            aslice = (aslice,)
+        return aslice
+
+    def get_filenames(self, aslice=None):
         """
         Return a list of file names referenced by this Array Container.
         """
-        names = []
-        for furi in np.asarray(self.fileuris).flat:
-            names.append(furi)
-        return names
+        reference_array = self.reference_array[aslice]
+        return [ear.fileuri for ear in reference_array.flat]
 
-    @abc.abstractproperty
-    def array(self):
+    def get_array(self, aslice=None):
         """
         Return an array type for the given array of external file references.
+
+        Parameters
+        ----------
+        aslice: tuple, slice
+            The slice of the array collection to generate an array for.
+        """
+        aslice = self._parse_aslice(aslice)
+        output_shape = self.get_output_shape(aslice)
+        return self._array_cache.get(aslice,
+                                     self.get_new_array(self.loader_array, aslice, output_shape))
+
+    @staticmethod
+    @abc.abstractmethod
+    def get_new_array(loader_array, aslice, output_shape):
+        """
+        Generate a whole new array.
         """
 
 
 @add_common_docstring(append=common_parameters)
-class NumpyFITSArrayContainer(BaseFITSArrayContainer):
+class NumpyFITSArrayCollection(BaseFITSArrayCollection):
     """
     Load an array of `~asdf.ExternalArrayReference` objects into a single
     in-memory numpy array.
     """
-
-    def __array__(self):
-        """
-        This dosen't seem to work if it returns a Dask array, so it's only
-        useful here.
-        """
-        return self.array
-
-    @property
-    def array(self):
+    @staticmethod
+    def get_new_array(loader_array, aslice, output_shape):
         """
         The `~numpy.ndarray` associated with this array of references.
         """
-        aa = list(map(np.asarray, self.loader_array.flat))
-        return np.stack(aa, axis=0).reshape(self.output_shape)
+        aa = list(map(np.asarray, loader_array[aslice].flat))
+        return np.stack(aa, axis=0).reshape(output_shape)
 
 
 @add_common_docstring(append=common_parameters)
-class DaskFITSArrayContainer(BaseFITSArrayContainer):
+class DaskFITSArrayCollection(BaseFITSArrayCollection):
     """
     Load an array of `~asdf.ExternalArrayReference` objects into a
     `dask.array.Array` object.
     """
 
-    @property
-    def array(self):
+    @staticmethod
+    def get_new_array(loader_array, aslice, output_shape):
         """
         The `~dask.array.Array` associated with this array of references.
         """
-        return stack_loader_array(self.loader_array).reshape(self.output_shape)
+        return stack_loader_array(loader_array[aslice]).reshape(output_shape)
 
 
 def stack_loader_array(loader_array):

--- a/dkist/io/asdf/tags/array_container.py
+++ b/dkist/io/asdf/tags/array_container.py
@@ -1,16 +1,16 @@
-
-
-
 from dkist.io import DaskFITSArrayCollection
 
 from ..types import DKISTType
 
 __all__ = ['ArrayContainerType']
 
+# Note: renaming this tag / schema from container to collection would have
+# invalidated all asdf files generated so far, to avoid this I haven't renamed
+# the tag / schema at the same time as the class it's serialising.
 
 class ArrayContainerType(DKISTType):
     name = "array_container"
-    types = ['dkist.io.array_containers.BaseFITSArrayCollection']
+    types = ['dkist.io.array_collections.BaseFITSArrayCollection']
     requires = ['dkist']
     version = "0.2.0"
 
@@ -19,8 +19,8 @@ class ArrayContainerType(DKISTType):
         return DaskFITSArrayCollection.from_tree(node, ctx)
 
     @classmethod
-    def to_tree(cls, array_container, ctx):
-        return array_container.to_tree(array_container, ctx)
+    def to_tree(cls, array_collection, ctx):
+        return array_collection.to_tree(array_collection, ctx)
 
     @classmethod
     def assert_equal(cls, old, new):

--- a/dkist/io/asdf/tags/array_container.py
+++ b/dkist/io/asdf/tags/array_container.py
@@ -1,7 +1,7 @@
 
 
 
-from dkist.io import DaskFITSArrayContainer
+from dkist.io import DaskFITSArrayCollection
 
 from ..types import DKISTType
 
@@ -10,13 +10,13 @@ __all__ = ['ArrayContainerType']
 
 class ArrayContainerType(DKISTType):
     name = "array_container"
-    types = ['dkist.io.array_containers.BaseFITSArrayContainer']
+    types = ['dkist.io.array_containers.BaseFITSArrayCollection']
     requires = ['dkist']
     version = "0.2.0"
 
     @classmethod
     def from_tree(cls, node, ctx):
-        return DaskFITSArrayContainer.from_tree(node, ctx)
+        return DaskFITSArrayCollection.from_tree(node, ctx)
 
     @classmethod
     def to_tree(cls, array_container, ctx):

--- a/dkist/io/asdf/tags/dataset.py
+++ b/dkist/io/asdf/tags/dataset.py
@@ -19,7 +19,7 @@ class DatasetType(DKISTType):
 
     @classmethod
     def from_tree(cls, node, ctx):
-        data = node["data"].get_array()
+        data = node["data"]
         wcs = node["wcs"]
         headers = node["headers"]
         meta = node.get("meta")
@@ -28,19 +28,17 @@ class DatasetType(DKISTType):
 
         dataset = Dataset(data, headers=headers, wcs=wcs, meta=meta,
                           unit=unit, mask=mask)
-        dataset._array_container = node["data"]
+        dataset._array_collection = node["data"]
         return dataset
 
     @classmethod
     def to_tree(cls, dataset, ctx):
-        if dataset._array_container is None:
-            raise ValueError("This Dataset object can not be saved to asdf as "
-                             "it was not constructed from a set of FITS files.")
         node = {}
         node["meta"] = dataset.meta or None
         node["wcs"] = dataset.wcs
         node["headers"] = dataset.headers
-        node["data"] = dataset._array_container
+        # TODO: Support slice here?
+        node["data"] = dataset.files.array_collection
         if dataset.unit:
             node["unit"] = dataset.unit
         if dataset.mask:
@@ -79,8 +77,8 @@ class DatasetType(DKISTType):
         assert old.meta == new.meta
         cls._assert_wcs_equal(old.wcs, new.wcs)
         cls._assert_table_equal(old.headers, new.headers)
-        ac_new = new._array_container.external_array_references
-        ac_old = old._array_container.external_array_references
+        ac_new = new.files.array_collection.external_array_references
+        ac_old = old.files.array_collection.external_array_references
         assert ac_new == ac_old
         assert old.unit == new.unit
         assert old.mask == new.mask

--- a/dkist/io/asdf/tags/dataset.py
+++ b/dkist/io/asdf/tags/dataset.py
@@ -19,7 +19,7 @@ class DatasetType(DKISTType):
 
     @classmethod
     def from_tree(cls, node, ctx):
-        data = node["data"].array
+        data = node["data"].get_array()
         wcs = node["wcs"]
         headers = node["headers"]
         meta = node.get("meta")

--- a/dkist/io/asdf/tests/test_dataset_tag.py
+++ b/dkist/io/asdf/tests/test_dataset_tag.py
@@ -6,7 +6,7 @@ import pytest
 import asdf
 from asdf.tests import helpers
 
-from dkist.io import AstropyFITSLoader, DaskFITSArrayContainer
+from dkist.io import AstropyFITSLoader, DaskFITSArrayCollection
 
 
 @pytest.fixture
@@ -19,8 +19,8 @@ def tagobj(request):
 
 @pytest.fixture
 def array_container():
-    return DaskFITSArrayContainer(['test1.fits', 'test2.fits'], 0, 'float', (10, 10),
-                                  loader=AstropyFITSLoader)
+    return DaskFITSArrayCollection(['test1.fits', 'test2.fits'], 0, 'float', (10, 10),
+                                   loader=AstropyFITSLoader)
 
 
 @pytest.mark.parametrize("tagobj",

--- a/dkist/io/asdf/tests/test_dataset_tag.py
+++ b/dkist/io/asdf/tests/test_dataset_tag.py
@@ -18,13 +18,13 @@ def tagobj(request):
 
 
 @pytest.fixture
-def array_container():
+def array_collection():
     return DaskFITSArrayCollection(['test1.fits', 'test2.fits'], 0, 'float', (10, 10),
                                    loader=AstropyFITSLoader)
 
 
 @pytest.mark.parametrize("tagobj",
-                         ["array_container",
+                         ["array_collection",
                           "dataset"],
                          indirect=True)
 def test_tags(tagobj, tmpdir):

--- a/dkist/io/tests/test_collections.py
+++ b/dkist/io/tests/test_collections.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose
 import asdf
 
 from dkist.data.test import rootdir
-from dkist.io.array_containers import (DaskFITSArrayCollection, ExternalArrayReferenceCollection,
+from dkist.io.array_collections import (DaskFITSArrayCollection, ExternalArrayReferenceCollection,
                                        NumpyFITSArrayCollection)
 from dkist.io.loaders import AstropyFITSLoader
 
@@ -22,7 +22,7 @@ def externalarray():
     """
     with asdf.open(
             os.path.join(eitdir, "eit_test_dataset.asdf")) as f:
-        return f.tree['dataset']._array_container.external_array_references
+        return f.tree['dataset']._array_collection.external_array_references
 
 
 def test_slicing(externalarray):

--- a/dkist/io/utils.py
+++ b/dkist/io/utils.py
@@ -1,0 +1,24 @@
+from collections import UserDict
+
+__all__ = ['SliceCache']
+
+
+class SliceCache(UserDict):
+    """
+    A dictionary where the keys are `slice` objects.
+
+    Slices aren't hashable, so we do some crazy processing to convert them to tuples.
+    """
+    def _slice_to_hashable(self, aslice):
+        if isinstance(aslice, slice):
+            return aslice.__reduce__()[1]
+
+        return tuple((self._slice_to_hashable(sub_slice) for sub_slice in aslice))
+
+    def __getitem__(self, key):
+        key = self._slice_to_hashable(key)
+        return super().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        key = self._slice_to_hashable(key)
+        return super().__setitem__(key, item)

--- a/docs/io.rst
+++ b/docs/io.rst
@@ -10,10 +10,10 @@ expose a single Python array-like object. This is done by instantiating a
 object, these loader objects, provide a delayed-io interface to the FITS file,
 only opening the file for reading when the data or the header is accessed.
 
-The `~dkist.io.array_containers.BaseFITSArrayContainer` class handles
+The `~dkist.io.array_collections.BaseFITSArrayCollection` class handles
 converting an array of `asdf.ExternalArrayReference` objects into an array of
 `~dkist.io.loaders.BaseFITSLoader` objects and then providing a method of
-converting this array of loaders into an array class. Currently, a container for
+converting this array of loaders into an array class. Currently, a collection for
 `numpy.ndarray` and `dask.array.Array` are provided.
 
 API Reference
@@ -22,5 +22,5 @@ API Reference
 .. automodapi:: dkist.io.loaders
    :headings: #^
 
-.. automodapi:: dkist.io.array_containers
+.. automodapi:: dkist.io.array_collections
    :headings: #^


### PR DESCRIPTION
The objective of this PR is to rework how, and *where* we handle referencing the FITS files which back the data.

This is primarily motivated by fixing #59 and also the fact that if you slice a sub-dataset and then download the files for that subset, the parent cube isn't then backed by the downloaded data.