### PR TITLE
Make more properties of the FileManager class private

### DIFF
--- a/changelog/130.feature.rst
+++ b/changelog/130.feature.rst
@@ -1,0 +1,3 @@
+Modify the `dkist.io.FileManager` class so that most of the functionality
+exists in the new base class and the dowload method is in the separate child
+class. In addition make more of the API private to not confuse end users.

--- a/dkist/io/asdf/tags/dataset.py
+++ b/dkist/io/asdf/tags/dataset.py
@@ -19,7 +19,7 @@ class DatasetType(DKISTType):
 
     @classmethod
     def from_tree(cls, node, ctx):
-        data = node["data"].generate_array()
+        data = node["data"]._generate_array()
         wcs = node["wcs"]
         headers = node["headers"]
         meta = node.get("meta")

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -68,7 +68,7 @@ class SlicedFileManagerProxy:
             return tuple(list(self.reference_array.shape) + list(shape))
 
 
-class FileManager:
+class BaseFileManager:
     """
     Manage a collection of arrays in files and their conversion to a Dask Array.
     """
@@ -220,6 +220,8 @@ class FileManager:
         """
         return stack_loader_array(self.loader_array).reshape(self.output_shape)
 
+
+class FileManager(BaseFileManager):
     def download(self, path="/~/", destination_endpoint=None, progress=True):
         """
         Start a Globus file transfer for all files in this Dataset.

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -37,22 +37,22 @@ class SlicedFileManagerProxy:
         return super().__setattr__(name, value)
 
     def __len__(self):
-        return self.reference_array.size
+        return self._reference_array.size
 
     @property
-    def loader_array(self):
+    def _loader_array(self):
         """
         An array of `.BaseFITSLoader` objects.
         """
-        la = self.parent.loader_array
+        la = self.parent._loader_array
         return np.array(la[self.parent_slice])
 
     @property
-    def reference_array(self):
+    def _reference_array(self):
         """
         An array of `asdf.ExternalArrayReference` objects.
         """
-        ra = self.parent.reference_array
+        ra = self.parent._reference_array
         return np.array(ra[self.parent_slice])
 
     @property
@@ -62,10 +62,10 @@ class SlicedFileManagerProxy:
         if self.shape[0] == 1:
             shape = self.parent.shape[1:]
 
-        if len(self.reference_array) == 1:
+        if len(self._reference_array) == 1:
             return shape
         else:
-            return tuple(list(self.reference_array.shape) + list(shape))
+            return tuple(list(self._reference_array.shape) + list(shape))
 
 
 class BaseFileManager:
@@ -102,7 +102,7 @@ class BaseFileManager:
         self.target = target
         self._loader = loader
         self._basepath = None
-        self._reference_array = np.asarray(self._to_ears(fileuris), dtype=object)
+        self.__reference_array = np.asarray(self._to_ears(fileuris), dtype=object)
         # When this object is attached to a Dataset object this attribute will
         # be populated with a reference to that Dataset instance.
         self._ndcube = None
@@ -110,14 +110,14 @@ class BaseFileManager:
         # Use the setter to convert to a Path
         self.basepath = basepath
 
-        loader_array = np.empty_like(self.reference_array, dtype=object)
-        for i, ele in enumerate(self.reference_array.flat):
+        loader_array = np.empty_like(self._reference_array, dtype=object)
+        for i, ele in enumerate(self._reference_array.flat):
             loader_array.flat[i] = loader(ele, self)
 
-        self._loader_array = loader_array
+        self.__loader_array = loader_array
 
     def __len__(self):
-        return self.reference_array.size
+        return self._reference_array.size
 
     def __eq__(self, other):
         uri = self.filenames == other.filenames
@@ -128,7 +128,7 @@ class BaseFileManager:
         return all((uri, target, dtype, shape))
 
     def __getitem__(self, item):
-        item = sanitize_slices(item, self.reference_array.ndim)
+        item = sanitize_slices(item, self._reference_array.ndim)
         return SlicedFileManagerProxy(self, item)
 
     def _array_slice_to_reference_slice(self, aslice):
@@ -165,7 +165,7 @@ class BaseFileManager:
         """
         Represent this collection as a list of `asdf.ExternalArrayReference` objects.
         """
-        return self.reference_array.tolist()
+        return self._reference_array.tolist()
 
     @property
     def basepath(self):
@@ -179,18 +179,18 @@ class BaseFileManager:
         self._basepath = Path(value) if value is not None else None
 
     @property
-    def loader_array(self):
+    def _loader_array(self):
         """
         An array of `.BaseFITSLoader` objects.
         """
-        return self._loader_array
+        return self.__loader_array
 
     @property
-    def reference_array(self):
+    def _reference_array(self):
         """
         An array of `asdf.ExternalArrayReference` objects.
         """
-        return self._reference_array
+        return self.__reference_array
 
     @property
     def filenames(self):
@@ -198,7 +198,7 @@ class BaseFileManager:
         Return a list of file names referenced by this Array Container.
         """
         names = []
-        for ear in self.reference_array.flat:
+        for ear in self._reference_array.flat:
             names.append(ear.fileuri)
         return names
 
@@ -209,16 +209,16 @@ class BaseFileManager:
         if self.shape[0] == 1:
             shape = self.shape[1:]
 
-        if len(self.reference_array) == 1:
+        if len(self._reference_array) == 1:
             return shape
         else:
-            return tuple(list(self.reference_array.shape) + list(shape))
+            return tuple(list(self._reference_array.shape) + list(shape))
 
-    def generate_array(self):
+    def _generate_array(self):
         """
         The `~dask.array.Array` associated with this array of references.
         """
-        return stack_loader_array(self.loader_array).reshape(self.output_shape)
+        return stack_loader_array(self._loader_array).reshape(self.output_shape)
 
 
 class FileManager(BaseFileManager):

--- a/dkist/io/tests/test_file_manager.py
+++ b/dkist/io/tests/test_file_manager.py
@@ -31,15 +31,15 @@ def externalarray(file_manager):
 
 def test_slicing(file_manager, externalarray):
     ext_shape = np.array(externalarray, dtype=object).shape
-    assert file_manager.loader_array.shape == ext_shape
+    assert file_manager._loader_array.shape == ext_shape
     assert file_manager.output_shape == tuple(list(ext_shape) + [128, 128])
 
-    array = file_manager.generate_array().compute()
+    array = file_manager._generate_array().compute()
     assert isinstance(array, np.ndarray)
 
     sliced_manager = file_manager[5:8]
     ext_shape = np.array(externalarray[5:8], dtype=object).shape
-    assert sliced_manager.loader_array.shape == ext_shape
+    assert sliced_manager._loader_array.shape == ext_shape
     assert sliced_manager.output_shape == tuple(list(ext_shape) + [128, 128])
 
 
@@ -50,11 +50,11 @@ def test_filenames(file_manager, externalarray):
 
 def test_dask(file_manager, externalarray):
     ext_shape = np.array(externalarray, dtype=object).shape
-    assert file_manager.loader_array.shape == ext_shape
+    assert file_manager._loader_array.shape == ext_shape
     assert file_manager.output_shape == tuple(list(ext_shape) + [128, 128])
 
-    assert isinstance(file_manager.generate_array(), da.Array)
-    assert_allclose(file_manager.generate_array(), np.array(file_manager.generate_array()))
+    assert isinstance(file_manager._generate_array(), da.Array)
+    assert_allclose(file_manager._generate_array(), np.array(file_manager._generate_array()))
 
 
 def test_collection_to_references(tmpdir, file_manager):
@@ -75,7 +75,7 @@ def test_collection_getitem(tmpdir, file_manager):
 
 def test_basepath_change(file_manager):
     file_manager.basepath = None
-    array = file_manager.generate_array()
+    array = file_manager._generate_array()
     assert np.isnan(array).all()
     file_manager.basepath = eitdir
     assert not np.isnan(array).any()
@@ -83,7 +83,7 @@ def test_basepath_change(file_manager):
 
 def test_sliced_basepath_change(file_manager):
     file_manager.basepath = None
-    array = file_manager.generate_array()
+    array = file_manager._generate_array()
     assert np.isnan(array).all()
 
     sub_array = array[3:4]

--- a/dkist/io/tests/test_fits.py
+++ b/dkist/io/tests/test_fits.py
@@ -40,7 +40,7 @@ def relative_ac(relative_ear):
 
 @pytest.fixture
 def relative_fl(relative_ac):
-    return relative_ac.loader_array.flat[0]
+    return relative_ac._loader_array.flat[0]
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def absolute_ac(absolute_ear):
 
 @pytest.fixture
 def absolute_fl(absolute_ac):
-    return absolute_ac.loader_array.flat[0]
+    return absolute_ac._loader_array.flat[0]
 
 
 def test_construct(relative_fl, absolute_fl):
@@ -80,7 +80,7 @@ def test_array(absolute_fl):
 
 def test_nan(relative_ac, tmpdir):
     relative_ac.basepath = tmpdir
-    array = relative_ac.generate_array()
+    array = relative_ac._generate_array()
     assert_allclose(array[10:20, :], np.nan)
 
 


### PR DESCRIPTION
There is a lot going on under the hood in FileManager, almost all of it the user should not need to interact with, so make it private to declutter the docs