### PR TITLE
Add support for representing Tiled Datasets

### DIFF
--- a/changelog/143.feature.rst
+++ b/changelog/143.feature.rst
@@ -1,0 +1,4 @@
+Add support for tiled datasets in the spatial dimensions.
+
+This adds a new class `.TiledDataset` which holds a 2D grid of `.Dataset`
+objects, and associated asdf schemas to serialise them.

--- a/dkist/__init__.py
+++ b/dkist/__init__.py
@@ -5,7 +5,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 import astropy.config as _config
 
-from .dataset import Dataset  # noqa
+from .dataset import Dataset, TiledDataset  # noqa
 from .utils.sysinfo import system_info  # noqa
 
 try:
@@ -14,7 +14,7 @@ except DistributionNotFound:
     # package is not installed
     __version__ = "unknown"
 
-__all__ = ['Dataset', 'system_info']
+__all__ = ['TiledDataset', 'Dataset', 'system_info']
 
 
 def write_default_config():

--- a/dkist/conftest.py
+++ b/dkist/conftest.py
@@ -1,3 +1,4 @@
+import copy
 from pathlib import Path
 
 import dask.array as da
@@ -15,6 +16,7 @@ from sunpy.coordinates.frames import Helioprojective
 
 from dkist.data.test import rootdir
 from dkist.dataset import Dataset
+from dkist.dataset.tiled_dataset import TiledDataset
 from dkist.io import FileManager
 from dkist.io.loaders import AstropyFITSLoader
 
@@ -229,3 +231,12 @@ def eit_dataset():
     eitdir = Path(rootdir) / "EIT"
     with asdf.open(eitdir / "eit_test_dataset.asdf") as f:
         return f.tree['dataset']
+
+
+@pytest.fixture
+def simple_tiled_dataset(dataset):
+    datasets = [copy.deepcopy(dataset) for i in range(4)]
+    for ds in datasets:
+        ds.meta['inventory'] = dataset.meta['inventory']
+    dataset_array = np.array(datasets).reshape((2,2))
+    return TiledDataset(dataset_array, dataset.meta['inventory'])

--- a/dkist/dataset/__init__.py
+++ b/dkist/dataset/__init__.py
@@ -1,1 +1,2 @@
 from .dataset import Dataset
+from .tiled_dataset import TiledDataset

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -6,12 +6,6 @@ import pytest
 from dkist import Dataset, TiledDataset
 
 
-@pytest.fixture
-def simple_tiled_dataset(dataset):
-    dataset_array = np.array([dataset]*4).reshape((2,2))
-    return TiledDataset(dataset_array, dataset.meta['inventory'])
-
-
 def test_tiled_dataset(simple_tiled_dataset, dataset):
     assert isinstance(simple_tiled_dataset, TiledDataset)
     assert dataset in simple_tiled_dataset

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -1,0 +1,67 @@
+import copy
+
+import numpy as np
+import pytest
+
+from dkist import Dataset, TiledDataset
+
+
+@pytest.fixture
+def simple_tiled_dataset(dataset):
+    dataset_array = np.array([dataset]*4).reshape((2,2))
+    return TiledDataset(dataset_array, dataset.meta['inventory'])
+
+
+def test_tiled_dataset(simple_tiled_dataset, dataset):
+    assert isinstance(simple_tiled_dataset, TiledDataset)
+    assert dataset in simple_tiled_dataset
+    assert 5 not in simple_tiled_dataset
+    assert all([isinstance(t, Dataset) for t in simple_tiled_dataset.flat])
+    assert all([t.shape == (2,) for t in simple_tiled_dataset])
+    assert simple_tiled_dataset.inventory is dataset.meta['inventory']
+    assert simple_tiled_dataset.shape == (2, 2)
+
+
+@pytest.mark.parametrize("aslice", (np.s_[0,0],
+                                    np.s_[0],
+                                    np.s_[...,0],
+                                    np.s_[:,1],
+                                    np.s_[1,1],
+                                    np.s_[0:2, :]))
+def test_tiled_dataset_slice(simple_tiled_dataset, aslice):
+    assert np.all(simple_tiled_dataset[aslice] == simple_tiled_dataset._data[aslice])
+
+
+def test_tiled_dataset_headers(simple_tiled_dataset, dataset):
+    assert len(simple_tiled_dataset.combined_headers) == len(dataset.meta['headers']) * 4
+    assert simple_tiled_dataset.combined_headers.colnames == dataset.meta['headers'].colnames
+
+
+def test_tiled_dataset_invalid_construction(dataset, dataset_4d):
+    with pytest.raises(ValueError, match="inventory record of the first dataset"):
+        TiledDataset(np.array((dataset, dataset_4d)))
+
+    with pytest.raises(ValueError, match="physical types do not match"):
+        TiledDataset(np.array((dataset, dataset_4d)), inventory=dataset.meta['inventory'])
+
+    ds2 = copy.deepcopy(dataset)
+    ds2.meta['inventory'] = {'hello': 'world'}
+    with pytest.raises(ValueError, match="inventory records of all the datasets"):
+        TiledDataset(np.array((dataset, ds2)), dataset.meta['inventory'])
+
+
+def test_tiled_dataset_from_components(dataset):
+    shape = (2, 2)
+    file_managers = [dataset._file_manager] * 4
+    wcses = [dataset.wcs] * 4
+    header_tables = [dataset.meta['headers']] * 4
+    inventory = dataset.meta['inventory']
+
+    tiled_ds = TiledDataset._from_components(shape, file_managers, wcses, header_tables, inventory)
+    assert isinstance(tiled_ds, TiledDataset)
+    assert tiled_ds.shape == shape
+    assert all([isinstance(t, Dataset) for t in tiled_ds.flat])
+    for ds, fm, headers in zip(tiled_ds.flat, file_managers, header_tables):
+        assert ds.files == fm
+        assert ds.meta['inventory'] is inventory
+        assert ds.meta['headers'] is headers

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -8,7 +8,7 @@ from dkist import Dataset, TiledDataset
 
 def test_tiled_dataset(simple_tiled_dataset, dataset):
     assert isinstance(simple_tiled_dataset, TiledDataset)
-    assert dataset in simple_tiled_dataset
+    assert simple_tiled_dataset._data[0, 0] in simple_tiled_dataset
     assert 5 not in simple_tiled_dataset
     assert all([isinstance(t, Dataset) for t in simple_tiled_dataset.flat])
     assert all([t.shape == (2,) for t in simple_tiled_dataset])

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -64,7 +64,10 @@ class TiledDataset(Collection):
         self._data = np.array(dataset_array, dtype=object)
         self._inventory = inventory or {}
         if not self._validate_component_datasets(self._data, inventory):
-            raise ValueError("All component datasets must have the same physical types and inventory dict")
+            raise ValueError(
+                "All component datasets must have the same"
+                " physical types and inventory dict"
+            )
 
     def __contains__(self, x):
         return self._data.__contains__(x)
@@ -74,6 +77,13 @@ class TiledDataset(Collection):
 
     def __iter__(self):
         self._data.__iter__()
+
+    def __getitem__(self, aslice):
+        new_data = self._data[aslice]
+        if isinstance(new_data, Dataset):
+            return new_data
+
+        return type(self)(new_data, inventory=self.inventory)
 
     @staticmethod
     def _validate_component_datasets(datasets, inventory):
@@ -111,9 +121,5 @@ class TiledDataset(Collection):
         """
         return self._data.shape
 
-    def __getitem__(self, aslice):
-        new_data = self._data[aslice]
-        if isinstance(new_data, Dataset):
-            return new_data
-
-        return type(self)(new_data, inventory=self.inventory)
+    # TODO: def plot()
+    # TODO: def regrid()

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -85,15 +85,13 @@ class TiledDataset(Collection):
     def _validate_component_datasets(datasets, inventory):
         datasets = datasets.flat
         inv_1 = datasets[0].meta["inventory"]
-        # TODO: Change this to is not when asdf reference code is fixed
-        if inv_1 and inv_1 != inventory:
+        if inv_1 and inv_1 is not inventory:
             raise ValueError("The inventory record of the first dataset does not match the one passed to TiledDataset")
         pt_1 = datasets[0].wcs.world_axis_physical_types
         for ds in datasets[1:]:
             if ds.wcs.world_axis_physical_types != pt_1:
                 raise ValueError("The physical types do not match between all datasets")
-            # TODO: Change this to is not when asdf reference code is fixed
-            if ds.meta["inventory"] and ds.meta["inventory"] != inventory:
+            if ds.meta["inventory"] and ds.meta["inventory"] is not inventory:
                 raise ValueError("The inventory records of all the datasets do not match the one passed to TiledDataset")
         return True
 

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -85,13 +85,15 @@ class TiledDataset(Collection):
     def _validate_component_datasets(datasets, inventory):
         datasets = datasets.flat
         inv_1 = datasets[0].meta["inventory"]
-        if inv_1 and inv_1 is not inventory:
+        # TODO: Change this to is not when asdf reference code is fixed
+        if inv_1 and inv_1 != inventory:
             raise ValueError("The inventory record of the first dataset does not match the one passed to TiledDataset")
         pt_1 = datasets[0].wcs.world_axis_physical_types
         for ds in datasets[1:]:
             if ds.wcs.world_axis_physical_types != pt_1:
                 raise ValueError("The physical types do not match between all datasets")
-            if ds.meta["inventory"] and ds.meta["inventory"] is not inventory:
+            # TODO: Change this to is not when asdf reference code is fixed
+            if ds.meta["inventory"] and ds.meta["inventory"] != inventory:
                 raise ValueError("The inventory records of all the datasets do not match the one passed to TiledDataset")
         return True
 

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -1,0 +1,38 @@
+"""
+Tiled datasets are one dataset which is made up of multiple smaller datasets tiled in space.
+
+A tiled dataset is a "dataset" in terms of how it's provided by the DKIST DC,
+but not representable in a single NDCube derived object as the array data are
+not contiguous in the spatial dimensions (due to overlaps and offsets).
+"""
+
+class TiledDataset:
+    """
+    A class for holding a dataset where the spatial axes are tiled.
+    """
+
+    def __init__(self, dataset_array, meta=None):
+        self._data = np.array(dataset_array, dtype=object)
+        if not self._validate_component_datasets(self._data):
+            raise ValueError("All component datasets must have the same physical types")
+        self._meta = meta
+
+    @staticmethod
+    def _validate_component_datasets(datasets):
+        datasets = datasets.flat
+        pt_1 = datasets[0].world_axis_physical_types
+        for ds in datasets[1:]:
+            if ds.world_axis_physical_types != pt_1:
+                return False
+        return True
+
+    @property
+    def meta(self):
+        return self._meta
+
+    def __getitem__(self, aslice):
+        new_data = self._data[aslice]
+        if len(new_data) == 1:
+            return new_data
+
+        return type(self)(new_data, meta=self.meta)

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -5,27 +5,70 @@ A tiled dataset is a "dataset" in terms of how it's provided by the DKIST DC,
 but not representable in a single NDCube derived object as the array data are
 not contiguous in the spatial dimensions (due to overlaps and offsets).
 """
+from collections.abc import Collection
+
+import numpy as np
+
+from astropy.table import vstack
+
+from .dataset import Dataset
 
 __all__ = ['TiledDataset']
 
 
-class TiledDataset:
+class TiledDataset(Collection):
     """
     A class for holding a dataset where the spatial axes are tiled.
     """
 
-    def __init__(self, dataset_array, meta=None):
+    @classmethod
+    def _from_components(cls, shape, file_managers, wcses, header_tables, inventory):
+        """
+        Construct a TiledDataset from the component parts of all the sub-datasets.
+
+        This is intended to be used in the dkist-inventory package for creating
+        these objects to be saved to asdf.
+
+        The inputs need to be in numpy order, as the flat list of datasets will
+        be reshaped into the given shape.
+        """
+        assert len(file_managers) == len(wcses) == len(header_tables)
+
+        datasets = np.empty(len(file_managers), dtype=object)
+        for i, (fm, wcs, headers) in enumerate(zip(file_managers, wcses, header_tables)):
+            meta = {"inventory": inventory, "headers": headers}
+            datasets[i] = Dataset(fm._generate_array(), wcs=wcs, meta=meta)
+            datasets[i]._file_manager = fm
+        datasets = datasets.reshape(shape)
+
+        return cls(datasets, inventory)
+
+    def __init__(self, dataset_array, inventory={}):
         self._data = np.array(dataset_array, dtype=object)
-        if not self._validate_component_datasets(self._data):
-            raise ValueError("All component datasets must have the same physical types")
-        self._meta = meta
+        self._inventory = inventory
+        if not self._validate_component_datasets(self._data, inventory):
+            raise ValueError("All component datasets must have the same physical types and inventory dict")
+
+    def __contains__(self, x):
+        return self._data.__contains__(x)
+
+    def __len__(self):
+        return self._data.__len__()
+
+    def __iter__(self):
+        self._data.__iter__()
 
     @staticmethod
-    def _validate_component_datasets(datasets):
+    def _validate_component_datasets(datasets, inventory):
         datasets = datasets.flat
-        pt_1 = datasets[0].world_axis_physical_types
+        inv_1 = datasets[0].meta["inventory"]
+        if inv_1 and inv_1 is not inventory:
+            return False
+        pt_1 = datasets[0].wcs.world_axis_physical_types
         for ds in datasets[1:]:
-            if ds.world_axis_physical_types != pt_1:
+            if ds.wcs.world_axis_physical_types != pt_1:
+                return False
+            if ds.meta["inventory"] and ds.meta["inventory"] is not inventory:
                 return False
         return True
 
@@ -33,9 +76,17 @@ class TiledDataset:
     def meta(self):
         return self._meta
 
+    @property
+    def combined_headers(self):
+        return vstack([ds.meta["headers"] for ds in self._data.flat])
+
+    @property
+    def shape(self):
+        return self._data.shape
+
     def __getitem__(self, aslice):
         new_data = self._data[aslice]
-        if len(new_data) == 1:
+        if isinstance(new_data, Dataset):
             return new_data
 
         return type(self)(new_data, meta=self.meta)

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -73,8 +73,8 @@ class TiledDataset(Collection):
         return True
 
     @property
-    def meta(self):
-        return self._meta
+    def inventory(self):
+        return self._inventory
 
     @property
     def combined_headers(self):
@@ -89,4 +89,4 @@ class TiledDataset(Collection):
         if isinstance(new_data, Dataset):
             return new_data
 
-        return type(self)(new_data, meta=self.meta)
+        return type(self)(new_data, inventory=self.inventory)

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -6,6 +6,9 @@ but not representable in a single NDCube derived object as the array data are
 not contiguous in the spatial dimensions (due to overlaps and offsets).
 """
 
+__all__ = ['TiledDataset']
+
+
 class TiledDataset:
     """
     A class for holding a dataset where the spatial axes are tiled.

--- a/dkist/io/asdf/extension.py
+++ b/dkist/io/asdf/extension.py
@@ -5,6 +5,7 @@ from asdf.util import filepath_to_url
 
 from .tags.array_container import ArrayContainerType  # noqa
 from .tags.dataset import DatasetType  # noqa
+from .tags.tiled_dataset import TiledDatasetType  # noqa
 from .types import DKISTType
 
 __all__ = ['DKISTExtension']

--- a/dkist/io/asdf/schemas/dkist.nso.edu/dkist/tiled_dataset-0.1.0.yaml
+++ b/dkist/io/asdf/schemas/dkist.nso.edu/dkist/tiled_dataset-0.1.0.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://dkist.nso.edu/schemas/dkist/tiled_dataset-0.1.0"
+tag: "tag:dkist.nso.edu:dkist/tiled_dataset-0.1.0"
+
+title: |
+  A DKIST Tiled Dataset object.
+description:
+  The container for a set of Dataset objects.
+
+type: object
+properties:
+  datasets:
+    $ref: "http://dkist.nso.edu/schemas/dkist/dataset-0.3.0"
+  inventory:
+    description: A copy of the inventory record for this dataset.
+    type: object
+
+required: [datasets, inventory]
+additionalProperties: false
+...

--- a/dkist/io/asdf/schemas/dkist.nso.edu/dkist/tiled_dataset-0.1.0.yaml
+++ b/dkist/io/asdf/schemas/dkist.nso.edu/dkist/tiled_dataset-0.1.0.yaml
@@ -12,7 +12,12 @@ description:
 type: object
 properties:
   datasets:
-    $ref: "http://dkist.nso.edu/schemas/dkist/dataset-0.3.0"
+    description: A nested structure of Dataset objects
+    type: array
+    items:
+      type: array
+      items:
+        $ref: "http://dkist.nso.edu/schemas/dkist/dataset-0.3.0"
   inventory:
     description: A copy of the inventory record for this dataset.
     type: object

--- a/dkist/io/asdf/tags/dataset.py
+++ b/dkist/io/asdf/tags/dataset.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 
 from asdf.yamlutil import custom_tree_to_tagged_tree

--- a/dkist/io/asdf/tags/dataset.py
+++ b/dkist/io/asdf/tags/dataset.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-from asdf.yamlutil import custom_tree_to_tagged_tree
-
 from dkist.dataset import Dataset
 
 from ..types import DKISTType
@@ -50,7 +48,7 @@ class DatasetType(DKISTType):
         if dataset.mask:
             node["mask"] = dataset.mask
 
-        return custom_tree_to_tagged_tree(node, ctx)
+        return node
 
     @staticmethod
     def _assert_wcs_equal(old, new):

--- a/dkist/io/asdf/tags/tiled_dataset.py
+++ b/dkist/io/asdf/tags/tiled_dataset.py
@@ -1,6 +1,6 @@
 from asdf.yamlutil import custom_tree_to_tagged_tree
 
-from dkist.tiled_dataset import TiledDataset
+from dkist.dataset.tiled_dataset import TiledDataset
 
 from ..types import DKISTType
 
@@ -9,7 +9,7 @@ __all__ = ["DatasetType"]
 
 class TiledDatasetType(DKISTType):
     name = "tiled_dataset"
-    types = ["dkist.dataset.tiled_dataset.TiledDataset"]
+    types = ["dkist.dataset.TiledDataset"]
     requires = ["dkist"]
     version = "0.1.0"
     supported_versions = ["0.1.0"]
@@ -21,8 +21,8 @@ class TiledDatasetType(DKISTType):
     @classmethod
     def to_tree(cls, tiled_dataset, ctx):
         tree = {}
-        tree["datasets"] = tiled_datasets._data.tolist()
-        tree["inventory"] = tiled_datasets._inventory
+        tree["inventory"] = tiled_dataset._inventory
+        tree["datasets"] = tiled_dataset._data.tolist()
 
         return custom_tree_to_tagged_tree(tree, ctx)
 

--- a/dkist/io/asdf/tags/tiled_dataset.py
+++ b/dkist/io/asdf/tags/tiled_dataset.py
@@ -25,7 +25,3 @@ class TiledDatasetType(DKISTType):
         tree["datasets"] = tiled_dataset._data.tolist()
 
         return custom_tree_to_tagged_tree(tree, ctx)
-
-    @classmethod
-    def assert_equal(cls, old, new):
-        pass

--- a/dkist/io/asdf/tags/tiled_dataset.py
+++ b/dkist/io/asdf/tags/tiled_dataset.py
@@ -1,0 +1,31 @@
+from asdf.yamlutil import custom_tree_to_tagged_tree
+
+from dkist.tiled_dataset import TiledDataset
+
+from ..types import DKISTType
+
+__all__ = ["DatasetType"]
+
+
+class TiledDatasetType(DKISTType):
+    name = "tiled_dataset"
+    types = ["dkist.dataset.tiled_dataset.TiledDataset"]
+    requires = ["dkist"]
+    version = "0.1.0"
+    supported_versions = ["0.1.0"]
+
+    @classmethod
+    def from_tree(cls, node, ctx):
+        return TiledDataset(node["datasets"], node["inventory"])
+
+    @classmethod
+    def to_tree(cls, tiled_dataset, ctx):
+        tree = {}
+        tree["datasets"] = tiled_datasets._data.tolist()
+        tree["inventory"] = tiled_datasets._inventory
+
+        return custom_tree_to_tagged_tree(tree, ctx)
+
+    @classmethod
+    def assert_equal(cls, old, new):
+        pass

--- a/dkist/io/asdf/tags/tiled_dataset.py
+++ b/dkist/io/asdf/tags/tiled_dataset.py
@@ -25,3 +25,17 @@ class TiledDatasetType(DKISTType):
         tree["datasets"] = tiled_dataset._data.tolist()
 
         return custom_tree_to_tagged_tree(tree, ctx)
+
+    @classmethod
+    def assert_equal(cls, old, new):
+        """
+        This method is used by asdf to test that to_tree > from_tree gives an
+        equivalent object.
+        """
+        from .dataset import DatasetType
+
+        assert old.inventory == new.inventory
+
+        for old_ds, new_ds in zip(old.flat, new.flat):
+            # Use the other asdf type to assert equality of the dataset objects
+            DatasetType.assert_equal(old_ds, new_ds)

--- a/dkist/io/asdf/tests/test_dataset_tag.py
+++ b/dkist/io/asdf/tests/test_dataset_tag.py
@@ -30,22 +30,37 @@ def array_container():
 
 
 @pytest.mark.parametrize("tagobj",
-                         ["array_container",
-                          "dataset"],
+                         [
+                             "array_container",
+                             "dataset",
+                             "simple_tiled_dataset",
+                         ],
                          indirect=True)
 def test_tags(tagobj, tmpdir):
     tree = {'object': tagobj}
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
-def test_save_dataset_without_file_schema(tmpdir, dataset):
-    tree = {'dataset': dataset}
+@pytest.mark.parametrize("tagobj",
+                         [
+                             "dataset",
+                             "simple_tiled_dataset",
+                         ],
+                         indirect=True)
+def test_save_dataset_without_file_schema(tagobj, tmpdir):
+    tree = {'dataset': tagobj}
     with asdf.AsdfFile(tree) as afile:
         afile.write_to(Path(tmpdir / "test.asdf"))
 
 
-def test_save_dataset_with_file_schema(tmpdir, dataset):
-    tree = {'dataset': dataset}
+@pytest.mark.parametrize("tagobj",
+                         [
+                             "dataset",
+                             "simple_tiled_dataset",
+                         ],
+                         indirect=True)
+def test_save_dataset_with_file_schema(tagobj, tmpdir):
+    tree = {'dataset': tagobj}
     with resources.path("dkist.io", "level_1_dataset_schema.yaml") as schema_path:
         with asdf.AsdfFile(tree, custom_schema=schema_path.as_posix()) as afile:
             afile.write_to(Path(tmpdir / "test.asdf"))

--- a/dkist/io/level_1_dataset_schema.yaml
+++ b/dkist/io/level_1_dataset_schema.yaml
@@ -15,6 +15,7 @@ properties:
       - $ref: "http://dkist.nso.edu/schemas/dkist/dataset-0.1.0"
       - $ref: "http://dkist.nso.edu/schemas/dkist/dataset-0.2.0"
       - $ref: "http://dkist.nso.edu/schemas/dkist/dataset-0.3.0"
+      - $ref: "http://dkist.nso.edu/schemas/dkist/tiled_dataset-0.1.0"
 
 required: [dataset]
 additionalProperties: true

--- a/dkist/net/tests/test_client.py
+++ b/dkist/net/tests/test_client.py
@@ -154,7 +154,8 @@ def test_apply_or_and(s):
     assert isinstance(s, (attr.AttrOr, attr.DataAttr, attr.AttrAnd))
 
 
-@settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture])
+@settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+          deadline=None)
 @given(dst.query_and())
 def test_search_query_and(mocked_client, query):
     res = mocked_client.search(query)
@@ -162,7 +163,8 @@ def test_search_query_and(mocked_client, query):
     assert len(res) == 1
 
 
-@settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture])
+@settings(suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+          deadline=None)
 @given(dst.query_or_composite())
 def test_search_query_or(mocked_client, query):
     res = mocked_client.search(query)


### PR DESCRIPTION
This is primarily for the VBI, where it can generate either a 2x2 or 3x3 array of spatial tiles, but could also be useful for other instruments.

This creates a new class `TiledDataset` which is a container for N `Dataset` objects.