### PR TITLE
Migrate away from using assert_roundtrip_tree in asdf tests

### DIFF
--- a/dkist/io/asdf/tags/array_container.py
+++ b/dkist/io/asdf/tags/array_container.py
@@ -18,11 +18,3 @@ class ArrayContainerType(DKISTType):
     @classmethod
     def to_tree(cls, array_container, ctx):
         return array_container.to_tree(array_container, ctx)
-
-    @classmethod
-    def assert_equal(cls, old, new):
-        """
-        This method is used by asdf to test that to_tree > from_tree gives an
-        equivalent object.
-        """
-        assert new == old

--- a/dkist/io/asdf/tags/dataset.py
+++ b/dkist/io/asdf/tags/dataset.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from dkist.dataset import Dataset
 
 from ..types import DKISTType
@@ -49,40 +47,3 @@ class DatasetType(DKISTType):
             node["mask"] = dataset.mask
 
         return node
-
-    @staticmethod
-    def _assert_wcs_equal(old, new):
-        assert old.name == new.name
-        assert len(old.available_frames) == len(new.available_frames)
-
-    @classmethod
-    def _assert_table_equal(cls, old, new):
-        from asdf.tags.core.ndarray import NDArrayType
-        assert old.meta == new.meta
-        try:
-            NDArrayType.assert_equal(np.array(old), np.array(new))
-        except (AttributeError, TypeError, ValueError):
-            for col0, col1 in zip(old, new):
-                try:
-                    NDArrayType.assert_equal(np.array(col0), np.array(col1))
-                except (AttributeError, TypeError, ValueError):
-                    assert col0 == col1
-
-    @classmethod
-    def assert_equal(cls, old, new):
-        """
-        This method is used by asdf to test that to_tree > from_tree gives an
-        equivalent object.
-        """
-        old_headers = old.meta.pop("headers")
-        new_headers = new.meta.pop("headers")
-        cls._assert_table_equal(old_headers, new_headers)
-        assert old.meta == new.meta
-        old.meta["headers"] = old_headers
-        new.meta["headers"] = new_headers
-        cls._assert_wcs_equal(old.wcs, new.wcs)
-        ac_new = new.files.external_array_references
-        ac_old = old.files.external_array_references
-        assert ac_new == ac_old
-        assert old.unit == new.unit
-        assert old.mask == new.mask

--- a/dkist/io/asdf/tags/tiled_dataset.py
+++ b/dkist/io/asdf/tags/tiled_dataset.py
@@ -25,17 +25,3 @@ class TiledDatasetType(DKISTType):
         tree["datasets"] = tiled_dataset._data.tolist()
 
         return custom_tree_to_tagged_tree(tree, ctx)
-
-    @classmethod
-    def assert_equal(cls, old, new):
-        """
-        This method is used by asdf to test that to_tree > from_tree gives an
-        equivalent object.
-        """
-        from .dataset import DatasetType
-
-        assert old.inventory == new.inventory
-
-        for old_ds, new_ds in zip(old.flat, new.flat):
-            # Use the other asdf type to assert equality of the dataset objects
-            DatasetType.assert_equal(old_ds, new_ds)

--- a/dkist/io/asdf/tests/helpers.py
+++ b/dkist/io/asdf/tests/helpers.py
@@ -1,0 +1,31 @@
+try:
+    from asdf.helpers import roundtrip_object
+except ImportError:
+    from io import BytesIO
+
+    import asdf
+
+
+    def roundtrip_object(obj, version=None):
+        """
+        Add the specified object to an AsdfFile's tree, write the file to
+        a buffer, then read it back in and return the deserialized object.
+        Parameters
+        ----------
+        obj : object
+            Object to serialize.
+        version : str or None.
+            ASDF Standard version.  If None, use the library's default version.
+        Returns
+        -------
+        object
+            The deserialized object.
+        """
+        buff = BytesIO()
+        with asdf.AsdfFile(version=version) as af:
+            af["obj"] = obj
+            af.write_to(buff)
+
+        buff.seek(0)
+        with asdf.open(buff, lazy_load=False, copy_arrays=True) as af:
+            return af["obj"]


### PR DESCRIPTION
This is going away in 3.0 so we migrate away now before I refactor all the asdf plugin