### PR TITLE
Varying celestial models with 2D lookup tables

### DIFF
--- a/changelog/161.feature.rst
+++ b/changelog/161.feature.rst
@@ -1,0 +1,2 @@
+Implement models where the poiting varies along the second pixel axis (for
+rastering slit spectrographs).

--- a/dkist/io/asdf/converters/models.py
+++ b/dkist/io/asdf/converters/models.py
@@ -9,34 +9,36 @@ class VaryingCelestialConverter(TransformConverterBase):
     types = [
         "dkist.wcs.models.VaryingCelestialTransform",
         "dkist.wcs.models.InverseVaryingCelestialTransform",
+        "dkist.wcs.models.VaryingCelestialTransform2D",
+        "dkist.wcs.models.InverseVaryingCelestialTransform2D",
     ]
 
     def select_tag(self, obj, tags, ctx):
-        from dkist.wcs.models import InverseVaryingCelestialTransform, VaryingCelestialTransform
-        if isinstance(obj, VaryingCelestialTransform):
+        from dkist.wcs.models import (InverseVaryingCelestialTransform,
+                                      InverseVaryingCelestialTransform2D,
+                                      VaryingCelestialTransform, VaryingCelestialTransform2D)
+        if isinstance(obj, (VaryingCelestialTransform, VaryingCelestialTransform2D)):
             return "asdf://dkist.nso.edu/tags/varying_celestial_transform-1.0.0"
-        elif isinstance(obj, InverseVaryingCelestialTransform):
+        elif isinstance(obj, (InverseVaryingCelestialTransform, InverseVaryingCelestialTransform2D)):
             return "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform-1.0.0"
         else:
             raise ValueError(f"Unsupported object: {obj}")  # pragma: no cover
 
     def from_yaml_tree_transform(self, node, tag, ctx):
-        from dkist.wcs.models import InverseVaryingCelestialTransform, VaryingCelestialTransform
+        from dkist.wcs.models import varying_celestial_transform_from_tables
 
-        if tag.endswith("inverse_varying_celestial_transform-1.0.0"):
-            cls = InverseVaryingCelestialTransform
-        elif tag.endswith("varying_celestial_transform-1.0.0"):
-            cls = VaryingCelestialTransform
-        else:
-            raise ValueError(f"Unsupported tag: {tag}")  # pragma: no cover
+        inverse = False
+        if "inverse_varying_celestial_transform" in tag:
+            inverse = True
 
-        return cls(
+        return varying_celestial_transform_from_tables(
             crpix=node["crpix"],
             cdelt=node["cdelt"],
             lon_pole=node["lon_pole"],
             crval_table=node["crval_table"],
             pc_table=node["pc_table"],
             projection=node["projection"],
+            inverse=inverse,
         )
 
     def to_yaml_tree_transform(self, model, tag, ctx):

--- a/dkist/io/asdf/converters/models.py
+++ b/dkist/io/asdf/converters/models.py
@@ -5,22 +5,38 @@ class VaryingCelestialConverter(TransformConverterBase):
     tags = [
         "asdf://dkist.nso.edu/tags/varying_celestial_transform-1.0.0",
         "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform-1.0.0",
+        "asdf://dkist.nso.edu/tags/varying_celestial_transform_slit-1.0.0",
+        "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform_slit-1.0.0",
     ]
     types = [
         "dkist.wcs.models.VaryingCelestialTransform",
         "dkist.wcs.models.InverseVaryingCelestialTransform",
         "dkist.wcs.models.VaryingCelestialTransform2D",
         "dkist.wcs.models.InverseVaryingCelestialTransform2D",
+        "dkist.wcs.models.VaryingCelestialTransformSlit",
+        "dkist.wcs.models.InverseVaryingCelestialTransformSlit",
+        "dkist.wcs.models.VaryingCelestialTransformSlit2D",
+        "dkist.wcs.models.InverseVaryingCelestialTransformSlit2D",
     ]
 
     def select_tag(self, obj, tags, ctx):
         from dkist.wcs.models import (InverseVaryingCelestialTransform,
                                       InverseVaryingCelestialTransform2D,
-                                      VaryingCelestialTransform, VaryingCelestialTransform2D)
+                                      InverseVaryingCelestialTransformSlit,
+                                      InverseVaryingCelestialTransformSlit2D,
+                                      VaryingCelestialTransform, VaryingCelestialTransform2D,
+                                      VaryingCelestialTransformSlit,
+                                      VaryingCelestialTransformSlit2D)
+
         if isinstance(obj, (VaryingCelestialTransform, VaryingCelestialTransform2D)):
             return "asdf://dkist.nso.edu/tags/varying_celestial_transform-1.0.0"
         elif isinstance(obj, (InverseVaryingCelestialTransform, InverseVaryingCelestialTransform2D)):
             return "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform-1.0.0"
+        elif isinstance(obj, (VaryingCelestialTransformSlit, VaryingCelestialTransformSlit2D)):
+            return "asdf://dkist.nso.edu/tags/varying_celestial_transform_slit-1.0.0"
+        elif isinstance(obj, (InverseVaryingCelestialTransformSlit,
+                              InverseVaryingCelestialTransformSlit2D)):
+            return "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform_slit-1.0.0"
         else:
             raise ValueError(f"Unsupported object: {obj}")  # pragma: no cover
 
@@ -39,6 +55,7 @@ class VaryingCelestialConverter(TransformConverterBase):
             pc_table=node["pc_table"],
             projection=node["projection"],
             inverse=inverse,
+            slit="_slit" in tag
         )
 
     def to_yaml_tree_transform(self, model, tag, ctx):

--- a/dkist/io/asdf/resources/manifests/dkist-wcs-1.0.0.yaml
+++ b/dkist/io/asdf/resources/manifests/dkist-wcs-1.0.0.yaml
@@ -12,3 +12,7 @@ tags:
     tag_uri: "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform-1.0.0"
   - schema_uri: "asdf://dkist.nso.edu/schemas/coupled_compound_model-1.0.0"
     tag_uri: "asdf://dkist.nso.edu/tags/coupled_compound_model-1.0.0"
+  - schema_uri: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.0.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/varying_celestial_transform_slit-1.0.0"
+  - schema_uri: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.0.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform_slit-1.0.0"

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -124,7 +124,7 @@ class BaseFileManager:
         item = self._array_slice_to_reference_slice(item)
 
         # Apply slice as array, but then back to nested lists
-        uris = np.array(self.filenames)[item].tolist()
+        uris = np.array(self._fileuris)[item].tolist()
         if isinstance(uris, str):
             uris = [uris]
 

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -689,6 +689,7 @@ def varying_celestial_transform_from_tables(crpix: Union[Iterable[float], u.Quan
                                             lon_pole: Union[float, u.Quantity] = None,
                                             projection: Model = m.Pix2Sky_TAN(),
                                             inverse=False,
+                                            slit=False,
                                             ) -> BaseVaryingCelestialTransform:
     """
     Generate a `.BaseVaryingCelestialTransform` based on the dimensionality of the tables.
@@ -700,13 +701,22 @@ def varying_celestial_transform_from_tables(crpix: Union[Iterable[float], u.Quan
     if (table_d := len(table_shape)) not in (1, 2):
         raise ValueError("Only one or two dimensional lookup tables are supported.")
 
-    cls = VaryingCelestialTransform
-    if table_d == 2:
-        cls = VaryingCelestialTransform2D
     if inverse:
         cls = InverseVaryingCelestialTransform
+        if slit:
+            cls = InverseVaryingCelestialTransformSlit
         if table_d == 2:
             cls = InverseVaryingCelestialTransform2D
+            if slit:
+                cls = InverseVaryingCelestialTransformSlit2D
+    else:
+        cls = VaryingCelestialTransform
+        if slit:
+            cls = VaryingCelestialTransformSlit
+        if table_d == 2:
+            cls = VaryingCelestialTransform2D
+            if slit:
+                cls = VaryingCelestialTransformSlit2D
 
     return cls(
         crpix=crpix,

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -299,7 +299,7 @@ class BaseVaryingCelestialTransform2D(BaseVaryingCelestialTransform):
                 # Scalar parameters are reshaped to be length one arrays by modeling
                 sct = self.transform_at_index((zz, qq), crpix[0], cdelt[0], lon_pole[0])
 
-                # Call this transform for all values of x, y where z == zind
+                # Call this transform for all values of x, y where z == zind and q == qind
                 mask = np.logical_and(zind == zz, qind == qq)
                 if inverse:
                     xx, yy = sct.inverse(bx[mask], by[mask])
@@ -382,14 +382,14 @@ class BaseVaryingCelestialTransformSlit(BaseVaryingCelestialTransform):
             x_out = np.empty_like(bx)
             y_out = np.empty_like(by)
 
-        # We now loop over every unique value of z and compute the transform.
+        # We now loop over every unique value of y and compute the transform.
         # This means we make the minimum number of calls possible to the transform.
-        for yy in np.unique(yind):
+        for yyind in np.unique(yind):
             # Scalar parameters are reshaped to be length one arrays by modeling
-            sct = self.transform_at_index(yy, crpix[0], cdelt[0], lon_pole[0])
+            sct = self.transform_at_index(yyind, crpix[0], cdelt[0], lon_pole[0])
 
             # Call this transform for all values of x, y where y == yind
-            mask = yind == yy
+            mask = yind == yyind
             if inverse:
                 # Note this isn't use as the inverse of this model uses the
                 # standard 2D inverse.
@@ -502,7 +502,7 @@ class VaryingCelestialTransformSlit2D(BaseVaryingCelestialTransform):
             x_out = np.empty_like(bx)
             y_out = np.empty_like(by)
 
-        # We now loop over every unique value of z and compute the transform.
+        # We now loop over every unique value of y and z and compute the transform.
         # This means we make the minimum number of calls possible to the transform.
         for yyind in np.unique(yind):
             for zzind in np.unique(zind):

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -160,6 +160,9 @@ class BaseVaryingCelestialTransform(Model):
         cdelt = cdelt if cdelt is not None else self.cdelt
         lon_pole = lon_pole if lon_pole is not None else self.lon_pole
 
+        if ind > self.pc_table.shape[0] - 1 or ind < 0:
+            return m.Const1D(np.nan * u.arcsec) & m.Const1D(np.nan * u.arcsec)
+
         sct = generate_celestial_transform(crpix=crpix,
                                            cdelt=cdelt,
                                            pc=self.pc_table[ind],

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -160,8 +160,11 @@ class BaseVaryingCelestialTransform(Model):
         cdelt = cdelt if cdelt is not None else self.cdelt
         lon_pole = lon_pole if lon_pole is not None else self.lon_pole
 
+        fill_val = np.nan
+        if isinstance(crpix, u.Quantity):
+            fill_val = np.nan * u.deg
         if (np.array(ind) > np.array(self.table_shape) - 1).any() or (np.array(ind) < 0).any():
-            return m.Const1D(np.nan * u.arcsec) & m.Const1D(np.nan * u.arcsec)
+            return m.Const1D(fill_val) & m.Const1D(fill_val)
 
         sct = generate_celestial_transform(crpix=crpix,
                                            cdelt=cdelt,
@@ -388,7 +391,9 @@ class BaseVaryingCelestialTransformSlit(BaseVaryingCelestialTransform):
             # Call this transform for all values of x, y where y == yind
             mask = yind == yy
             if inverse:
-                xx, yy = sct.inverse(bx[mask], by[mask])
+                # Note this isn't use as the inverse of this model uses the
+                # standard 2D inverse.
+                xx, yy = sct.inverse(bx[mask], by[mask])  # pragma: no cover
             else:
                 xx, yy = sct(bx[mask], by[mask])
 
@@ -415,7 +420,7 @@ class VaryingCelestialTransformSlit(BaseVaryingCelestialTransformSlit):
         self.outputs = ("lon", "lat")
 
         if len(self.table_shape) != 1:
-            raise ValueError("This model can only be constructed with a two dimensional lookup table.")
+            raise ValueError("This model can only be constructed with a one dimensional lookup table.")
 
     @property
     def input_units(self):
@@ -507,7 +512,9 @@ class VaryingCelestialTransformSlit2D(BaseVaryingCelestialTransform):
                 # Call this transform for all values of x, y where z == zind
                 mask = np.logical_and(zind == zzind, yind == yyind)
                 if inverse:
-                    xx, yy = sct.inverse(bx[mask], by[mask])
+                    # Note this isn't use as the inverse of this model uses the
+                    # standard 2D inverse.
+                    xx, yy = sct.inverse(bx[mask], by[mask])  # pragma: no cover
                 else:
                     xx, yy = sct(bx[mask], by[mask])
 

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -160,7 +160,7 @@ class BaseVaryingCelestialTransform(Model):
         cdelt = cdelt if cdelt is not None else self.cdelt
         lon_pole = lon_pole if lon_pole is not None else self.lon_pole
 
-        if ind > self.pc_table.shape[0] - 1 or ind < 0:
+        if (np.array(ind) > np.array(self.table_shape) - 1).any() or (np.array(ind) < 0).any():
             return m.Const1D(np.nan * u.arcsec) & m.Const1D(np.nan * u.arcsec)
 
         sct = generate_celestial_transform(crpix=crpix,
@@ -499,13 +499,13 @@ class VaryingCelestialTransformSlit2D(BaseVaryingCelestialTransform):
 
         # We now loop over every unique value of z and compute the transform.
         # This means we make the minimum number of calls possible to the transform.
-        for yy in np.unique(yind):
-            for zz in np.unique(zind):
+        for yyind in np.unique(yind):
+            for zzind in np.unique(zind):
                 # Scalar parameters are reshaped to be length one arrays by modeling
-                sct = self.transform_at_index((zz, yy), crpix[0], cdelt[0], lon_pole[0])
+                sct = self.transform_at_index((zzind, yyind), crpix[0], cdelt[0], lon_pole[0])
 
                 # Call this transform for all values of x, y where z == zind
-                mask = np.logical_and(zind == zz, yind == yy)
+                mask = np.logical_and(zind == zzind, yind == yyind)
                 if inverse:
                     xx, yy = sct.inverse(bx[mask], by[mask])
                 else:

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -482,7 +482,7 @@ class CoupledCompoundModel(CompoundModel):
         cleft[: sepleft.shape[0], : sepleft.shape[1]] = sepleft
 
         cright = np.zeros((noutp, sepright.shape[1]))
-        cright[-sepright.shape[0]:, -sepright.shape[1]:] = 1
+        cright[-sepright.shape[0]:, -sepright.shape[1]:] = sepright
 
         left_solo_end = self.left.n_inputs - self.shared_inputs
         right_solo_start = left_solo_end + self.shared_inputs
@@ -490,6 +490,6 @@ class CoupledCompoundModel(CompoundModel):
         matrix[:, :left_solo_end] = cleft[:, :left_solo_end]
         matrix[:, left_solo_end:right_solo_start] = np.logical_or(cleft[:, left_solo_end:],
                                                                   cright[:, :self.shared_inputs])
-        matrix[:, right_solo_start:] = cright[:, :right_solo_start]
+        matrix[:, right_solo_start:] = cright[:, self.shared_inputs:]
 
         return matrix

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -270,7 +270,7 @@ class InverseVaryingCelestialTransform(BaseVaryingCelestialTransform):
         return self._map_transform(lon, lat, z, crpix, cdelt, lon_pole, inverse=True)
 
 
-class BaseVaryingCelestialTransform4D(BaseVaryingCelestialTransform):
+class BaseVaryingCelestialTransform2D(BaseVaryingCelestialTransform):
     def _map_transform(self, x, y, z, q, crpix, cdelt, lon_pole, inverse=False):
         # We need to broadcast the arrays together so they are all the same shape
         bx, by, bz, bq = np.broadcast_arrays(x, y, z, q, subok=True)
@@ -313,7 +313,7 @@ class BaseVaryingCelestialTransform4D(BaseVaryingCelestialTransform):
         return x_out, y_out
 
 
-class VaryingCelestialTransform4D(BaseVaryingCelestialTransform4D):
+class VaryingCelestialTransform2D(BaseVaryingCelestialTransform2D):
     n_inputs = 4
     n_outputs = 2
 
@@ -334,7 +334,7 @@ class VaryingCelestialTransform4D(BaseVaryingCelestialTransform4D):
 
     @property
     def inverse(self):
-        ivct = InverseVaryingCelestialTransform4D(crpix=self.crpix,
+        ivct = InverseVaryingCelestialTransform2D(crpix=self.crpix,
                                                   cdelt=self.cdelt,
                                                   lon_pole=self.lon_pole,
                                                   pc_table=self.pc_table,
@@ -343,7 +343,7 @@ class VaryingCelestialTransform4D(BaseVaryingCelestialTransform4D):
         return ivct
 
 
-class InverseVaryingCelestialTransform4D(BaseVaryingCelestialTransform4D):
+class InverseVaryingCelestialTransform2D(BaseVaryingCelestialTransform2D):
     n_inputs = 4
     n_outputs = 2
 
@@ -506,7 +506,8 @@ def varying_celestial_transform_from_tables(crpix: Union[Iterable[float], u.Quan
                                             pc_table: Union[ArrayLike, u.Quantity],
                                             crval_table: Union[Iterable[float], u.Quantity],
                                             lon_pole: Union[float, u.Quantity] = None,
-                                            projection: Model = m.Pix2Sky_TAN()
+                                            projection: Model = m.Pix2Sky_TAN(),
+                                            inverse=False,
                                             ) -> BaseVaryingCelestialTransform:
     """
     Generate a `.BaseVaryingCelestialTransform` based on the dimensionality of the tables.
@@ -520,7 +521,11 @@ def varying_celestial_transform_from_tables(crpix: Union[Iterable[float], u.Quan
 
     cls = VaryingCelestialTransform
     if table_d == 2:
-        cls = VaryingCelestialTransform4D
+        cls = VaryingCelestialTransform2D
+    if inverse:
+        cls = InverseVaryingCelestialTransform
+        if table_d == 2:
+            cls = InverseVaryingCelestialTransform2D
 
     return cls(
         crpix=crpix,

--- a/dkist/wcs/tests/test_coupled_compound_model.py
+++ b/dkist/wcs/tests/test_coupled_compound_model.py
@@ -145,7 +145,7 @@ def test_coupled_slit_no_repeat(linear_time):
     pixel = (0*u.pix, 4*u.pix)
     world = tfrm(*pixel)
     ipixel = tfrm.inverse(*world)
-    assert u.allclose(ipixel, pixel)
+    assert u.allclose(ipixel, pixel, atol=1e-5*u.pix)
 
 
 def test_coupled_slit_with_repeat(linear_time):

--- a/dkist/wcs/tests/test_coupled_compound_model.py
+++ b/dkist/wcs/tests/test_coupled_compound_model.py
@@ -3,10 +3,12 @@ import pytest
 
 import astropy.modeling.models as m
 import astropy.units as u
+from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.modeling import CompoundModel, Model
 from astropy.modeling.separable import separability_matrix
 
-from dkist.wcs.models import CoupledCompoundModel, VaryingCelestialTransform
+from dkist.wcs.models import (CoupledCompoundModel, VaryingCelestialTransform,
+                              VaryingCelestialTransform4D)
 
 
 @pytest.fixture
@@ -22,6 +24,18 @@ def vct_crval():
                                      crval_table=crval_table,
                                      pc_table=np.identity(2) * u.arcsec,
                                      lon_pole=180 * u.deg)
+
+
+@pytest.fixture
+def vct_4d_pc():
+    varying_matrix_lt = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.arcsec
+    varying_matrix_lt = varying_matrix_lt.reshape((5, 3, 2, 2))
+
+    return VaryingCelestialTransform4D(crpix=(5, 5) * u.pix,
+                                       cdelt=(1, 1) * u.arcsec/u.pix,
+                                       crval_table=(0, 0) * u.arcsec,
+                                       pc_table=varying_matrix_lt,
+                                       lon_pole=180 * u.deg)
 
 
 def test_coupled_init_error():
@@ -52,12 +66,65 @@ def test_coupled(vct_crval, linear_time):
     assert u.allclose(inverse(*world), pixel, atol=1e-9*u.pix)
 
 
+def test_coupled_4d(vct_4d_pc, linear_time):
+    double_time = linear_time & linear_time
+    tfrm = CoupledCompoundModel("&", vct_4d_pc, double_time, shared_inputs=2)
+
+    assert tfrm.n_inputs == 4
+    assert len(tfrm.inputs) == 4
+
+    pixel = (0, 0, 3, 2) * u.pix
+    world = tfrm(*pixel)
+    spatial_world = vct_4d_pc(*pixel)
+    temporal_world = double_time(*pixel[-2:])
+    assert u.allclose(spatial_world, world[:2])
+    assert u.allclose(temporal_world, world[-2:])
+
+    inverse = tfrm.inverse
+
+    assert inverse.n_inputs == 4
+    assert inverse.n_outputs == 4
+
+    assert isinstance(inverse, CompoundModel)
+
+    assert u.allclose(inverse(*world), pixel, atol=1e-9*u.pix)
+
+
 def test_coupled_sep(linear_time, vct_crval):
     if not hasattr(Model, "_calculate_separability_matrix"):
         pytest.skip()
 
     tfrm = CoupledCompoundModel("&", vct_crval, linear_time, shared_inputs=1)
     smatrix = separability_matrix(tfrm)
-    assert np.allclose(smatrix, np.array([[True,  True,  True],
-                                          [True,  True,  True],
-                                          [False, False, True]]))
+    assert np.allclose(smatrix, np.array([[1, 1, 1],
+                                          [1, 1, 1],
+                                          [0, 0, 1]]))
+
+
+def test_coupled_sep_4d(vct_4d_pc, linear_time):
+    if not hasattr(Model, "_calculate_separability_matrix"):
+        pytest.skip()
+    linear_spectral = m.Linear1D(slope=10*u.nm/u.pix)
+    right = linear_time & linear_spectral
+    tfrm = CoupledCompoundModel("&", vct_4d_pc, right, shared_inputs=2)
+
+    smatrix = separability_matrix(tfrm)
+    assert np.allclose(smatrix, np.array([[1, 1, 1, 1],
+                                          [1, 1, 1, 1],
+                                          [0, 0, 1, 0],
+                                          [0, 0, 0, 1]]))
+
+
+def test_coupled_sep_4d_extra(vct_4d_pc, linear_time):
+    if not hasattr(Model, "_calculate_separability_matrix"):
+        pytest.skip()
+    linear_spectral = m.Linear1D(slope=10*u.nm/u.pix)
+    right = linear_time & linear_spectral & linear_spectral
+    tfrm = CoupledCompoundModel("&", vct_4d_pc, right, shared_inputs=2)
+
+    smatrix = separability_matrix(tfrm)
+    assert np.allclose(smatrix, np.array([[1, 1, 1, 1, 0],
+                                          [1, 1, 1, 1, 0],
+                                          [0, 0, 1, 0, 0],
+                                          [0, 0, 0, 1, 0],
+                                          [0, 0, 0, 0, 1]]))

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -4,10 +4,9 @@ import pytest
 import astropy.modeling.models as m
 import astropy.units as u
 from astropy.coordinates.matrix_utilities import rotation_matrix
-from astropy.modeling import CompoundModel, Model
-from astropy.modeling.separable import separability_matrix
+from astropy.modeling import CompoundModel
 
-from dkist.wcs.models import (CoupledCompoundModel, VaryingCelestialTransform,
+from dkist.wcs.models import (VaryingCelestialTransform, VaryingCelestialTransform4D,
                               generate_celestial_transform)
 
 
@@ -185,62 +184,44 @@ def test_vct_errors():
                                   projection=ValueError)
 
 
-@pytest.fixture
-def linear_time():
-    return m.Linear1D(slope=1*u.s/u.pix, intercept=0*u.s)
+def test_varying_transform_4d_pc():
+    varying_matrix_lt = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.arcsec
+    varying_matrix_lt = varying_matrix_lt.reshape((3, 5, 2, 2))
+
+    vct = VaryingCelestialTransform4D(crpix=(5, 5) * u.pix,
+                                      cdelt=(1, 1) * u.arcsec/u.pix,
+                                      crval_table=(0, 0) * u.arcsec,
+                                      pc_table=varying_matrix_lt,
+                                      lon_pole=180 * u.deg)
+
+    pixel = 0*u.pix, 0*u.pix, 0*u.pix, 0*u.pix
+    world = vct(*pixel)
+    new_pixel = vct.inverse(*world, 0*u.pix, 0*u.pix)
+
+    assert u.allclose(new_pixel, pixel[:2], atol=0.01*u.pix)
 
 
-@pytest.fixture
-def vct_crval():
-    crval_table = ((0, 1), (2, 3), (4, 5)) * u.arcsec
-    return VaryingCelestialTransform(crpix=(5, 5) * u.pix,
-                                     cdelt=(1, 1) * u.arcsec/u.pix,
-                                     crval_table=crval_table,
-                                     pc_table=np.identity(2) * u.arcsec,
-                                     lon_pole=180 * u.deg)
+@pytest.mark.parametrize(("pixel", "lon_shape"), (
+    ((*np.mgrid[0:5, 0:5] * u.pix, np.arange(5) * u.pix, 0 * u.pix), (5, 5)),
+    (np.mgrid[0:10, 0:10, 0:5, 0:3] * u.pix, (10, 10, 5, 3)),
+    ((2 * u.pix, 2 * u.pix, 0*u.pix, np.arange(3) * u.pix), (3,)),
+    ((np.arange(10) * u.pix,
+      np.arange(10) * u.pix,
+      np.arange(5)[..., None] * u.pix,
+      np.arange(3)[..., None, None]), (3, 5, 10)),
+))
+def test_varying_transform_4d_pc_shapes(pixel, lon_shape):
+    varying_matrix_lt = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.arcsec
+    varying_matrix_lt = varying_matrix_lt.reshape((5, 3, 2, 2))
 
-
-def test_coupled_init_error():
-    with pytest.raises(ValueError, match="only be used with the & operator"):
-        CoupledCompoundModel("|", None, None)
-
-
-def test_coupled(vct_crval, linear_time):
-    tfrm = CoupledCompoundModel("&", vct_crval, linear_time, shared_inputs=1)
-
-    assert tfrm.n_inputs == 3
-    assert len(tfrm.inputs) == 3
-
-    pixel = (0, 0, 2) * u.pix
-    world = tfrm(*pixel)
-    spatial_world = vct_crval(*pixel)
-    temporal_world = linear_time(pixel[2])
-    assert u.allclose(spatial_world, world[:2])
-    assert u.allclose(temporal_world, world[2])
-
-    inverse = tfrm.inverse
-
-    assert inverse.n_inputs == 3
-    assert inverse.n_outputs == 3
-
-    assert isinstance(inverse, CompoundModel)
-
-    assert u.allclose(inverse(*world), pixel, atol=1e-9*u.pix)
-
-
-def test_coupled_sep(linear_time):
-    if not hasattr(Model, "_calculate_separability_matrix"):
-        pytest.skip()
-
-    crval_table = ((0, 1), (2, 3), (4, 5)) * u.arcsec
-    vct = VaryingCelestialTransform(crpix=(5, 5) * u.pix,
-                                    cdelt=(1, 1) * u.arcsec/u.pix,
-                                    crval_table=crval_table,
-                                    pc_table=np.identity(2) * u.arcsec,
-                                    lon_pole=180 * u.deg)
-
-    tfrm = CoupledCompoundModel("&", vct, linear_time, shared_inputs=1)
-    smatrix = separability_matrix(tfrm)
-    assert np.allclose(smatrix, np.array([[True,  True,  True],
-                                          [True,  True,  True],
-                                          [False, False, True]]))
+    vct = VaryingCelestialTransform4D(crpix=(5, 5) * u.pix,
+                                      cdelt=(1, 1) * u.arcsec/u.pix,
+                                      crval_table=(0, 0) * u.arcsec,
+                                      pc_table=varying_matrix_lt,
+                                      lon_pole=180 * u.deg)
+    world = vct(*pixel)
+    assert np.array(world[0]).shape == lon_shape
+    new_pixel = vct.inverse(*world, *pixel[-2:])
+    assert u.allclose(new_pixel,
+                      np.broadcast_arrays(*pixel, subok=True)[:2],
+                      atol=0.01*u.pix)

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.modeling import CompoundModel
 
-from dkist.wcs.models import (VaryingCelestialTransform, VaryingCelestialTransform4D,
+from dkist.wcs.models import (VaryingCelestialTransform, VaryingCelestialTransform2D,
                               generate_celestial_transform,
                               varying_celestial_transform_from_tables)
 
@@ -189,7 +189,7 @@ def test_varying_transform_4d_pc():
     varying_matrix_lt = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.arcsec
     varying_matrix_lt = varying_matrix_lt.reshape((3, 5, 2, 2))
 
-    vct = VaryingCelestialTransform4D(crpix=(5, 5) * u.pix,
+    vct = VaryingCelestialTransform2D(crpix=(5, 5) * u.pix,
                                       cdelt=(1, 1) * u.arcsec/u.pix,
                                       crval_table=(0, 0) * u.arcsec,
                                       pc_table=varying_matrix_lt,
@@ -206,7 +206,7 @@ def test_varying_transform_4d_pc_unitless():
     varying_matrix_lt = np.array([rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)])
     varying_matrix_lt = varying_matrix_lt.reshape((3, 5, 2, 2))
 
-    vct = VaryingCelestialTransform4D(crpix=(5, 5),
+    vct = VaryingCelestialTransform2D(crpix=(5, 5),
                                       cdelt=(1, 1),
                                       crval_table=(0, 0),
                                       pc_table=varying_matrix_lt,
@@ -232,7 +232,7 @@ def test_varying_transform_4d_pc_shapes(pixel, lon_shape):
     varying_matrix_lt = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.arcsec
     varying_matrix_lt = varying_matrix_lt.reshape((5, 3, 2, 2))
 
-    vct = VaryingCelestialTransform4D(crpix=(5, 5) * u.pix,
+    vct = VaryingCelestialTransform2D(crpix=(5, 5) * u.pix,
                                       cdelt=(1, 1) * u.arcsec/u.pix,
                                       crval_table=(0, 0) * u.arcsec,
                                       pc_table=varying_matrix_lt,
@@ -262,11 +262,11 @@ def test_vct_dispatch():
 
     assert isinstance(vct_3d, VaryingCelestialTransform)
 
-    vct_4d = varying_celestial_transform_from_tables(pc_table=varying_matrix_lt,
+    vct_2d = varying_celestial_transform_from_tables(pc_table=varying_matrix_lt,
                                                      crval_table=crval_table,
                                                      **kwargs)
 
-    assert isinstance(vct_4d, VaryingCelestialTransform4D)
+    assert isinstance(vct_2d, VaryingCelestialTransform2D)
 
     with pytest.raises(ValueError, match="Only one or two dimensional lookup tables are supported"):
         varying_celestial_transform_from_tables(pc_table=varying_matrix_lt[1:].reshape((3, 2, 2, 2, 2)),

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -201,6 +201,23 @@ def test_varying_transform_4d_pc():
     assert u.allclose(new_pixel, pixel[:2], atol=0.01*u.pix)
 
 
+def test_varying_transform_4d_pc_unitless():
+    varying_matrix_lt = np.array([rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)])
+    varying_matrix_lt = varying_matrix_lt.reshape((3, 5, 2, 2))
+
+    vct = VaryingCelestialTransform4D(crpix=(5, 5),
+                                      cdelt=(1, 1),
+                                      crval_table=(0, 0),
+                                      pc_table=varying_matrix_lt,
+                                      lon_pole=180)
+
+    pixel = 0, 0, 0, 0
+    world = vct(*pixel)
+    new_pixel = vct.inverse(*world, 0, 0)
+
+    assert u.allclose(new_pixel, pixel[:2], atol=0.01)
+
+
 @pytest.mark.parametrize(("pixel", "lon_shape"), (
     ((*np.mgrid[0:5, 0:5] * u.pix, np.arange(5) * u.pix, 0 * u.pix), (5, 5)),
     (np.mgrid[0:10, 0:10, 0:5, 0:3] * u.pix, (10, 10, 5, 3)),

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -272,3 +272,20 @@ def test_vct_dispatch():
         varying_celestial_transform_from_tables(pc_table=varying_matrix_lt[1:].reshape((3, 2, 2, 2, 2)),
                                                 crval_table=crval_table[1:].reshape((3, 2, 2, 2)),
                                                 **kwargs)
+
+def test_vct_shape_errors():
+    pc_table = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.arcsec
+    pc_table = pc_table.reshape((5, 3, 2, 2))
+
+    crval_table = list(zip(np.arange(1, 16), np.arange(16, 31))) * u.arcsec
+    crval_table = crval_table.reshape((5, 3, 2))
+
+    kwargs = dict(crpix=(5, 5) * u.pix,
+                  cdelt=(1, 1) * u.arcsec/u.pix,
+                  lon_pole=180 * u.deg)
+
+    with pytest.raises(ValueError, match="only be constructed with a one dimensional"):
+        VaryingCelestialTransform(crval_table=crval_table, pc_table=pc_table, **kwargs)
+
+    with pytest.raises(ValueError, match="only be constructed with a two dimensional"):
+        VaryingCelestialTransform2D(crval_table=crval_table[0], pc_table=pc_table[0], **kwargs)


### PR DESCRIPTION
This is a variant of the 3D model useful for VISP.

Todo:

- [x] Create a model which takes a 2D lookup table but only one extra index. Where the y pixel dimension is also used as the first index to the lookup table.
- [x] Also need a variant of the 1D table model where it takes no extra inputs and just varies with the y input.