### PR TITLE
Initial pass at a two layer refactor of FileManager

### DIFF
--- a/changelog/176.bugfix.rst
+++ b/changelog/176.bugfix.rst
@@ -1,0 +1,1 @@
+Refactor `.FileManager` to correctly support slicing.

--- a/dkist/__init__.py
+++ b/dkist/__init__.py
@@ -5,7 +5,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 import astropy.config as _config
 
-# from .dataset import Dataset, TiledDataset  # noqa
+from .dataset import Dataset, TiledDataset  # noqa
 from .utils.sysinfo import system_info  # noqa
 
 try:

--- a/dkist/__init__.py
+++ b/dkist/__init__.py
@@ -5,7 +5,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 import astropy.config as _config
 
-from .dataset import Dataset, TiledDataset  # noqa
+# from .dataset import Dataset, TiledDataset  # noqa
 from .utils.sysinfo import system_info  # noqa
 
 try:

--- a/dkist/conftest.py
+++ b/dkist/conftest.py
@@ -214,8 +214,8 @@ def dataset(array, identity_gwcs):
     assert ds.data is array
     assert ds.wcs is identity_gwcs
 
-    ds._file_manager = FileManager(['test1.fits'], 0, 'float', array.shape,
-                                   loader=AstropyFITSLoader)
+    ds._file_manager = FileManager.from_parts(['test1.fits'], 0, 'float', array.shape,
+                                              loader=AstropyFITSLoader)
 
     return ds
 

--- a/dkist/io/asdf/converters/dataset.py
+++ b/dkist/io/asdf/converters/dataset.py
@@ -13,7 +13,7 @@ class DatasetConverter(Converter):
     def from_yaml_tree(self, node, tag, ctx):
         from dkist.dataset import Dataset
 
-        data = node["data"]._generate_array()
+        data = node["data"]._fits_loader._generate_array()
         wcs = node["wcs"]
         meta = node.get("meta", {})
         unit = node.get("unit")

--- a/dkist/io/asdf/converters/dataset.py
+++ b/dkist/io/asdf/converters/dataset.py
@@ -13,7 +13,7 @@ class DatasetConverter(Converter):
     def from_yaml_tree(self, node, tag, ctx):
         from dkist.dataset import Dataset
 
-        data = node["data"]._fits_loader._generate_array()
+        data = node["data"]._striped_external_array._generate_array()
         wcs = node["wcs"]
         meta = node.get("meta", {})
         unit = node.get("unit")

--- a/dkist/io/asdf/converters/file_manager.py
+++ b/dkist/io/asdf/converters/file_manager.py
@@ -24,18 +24,18 @@ class FileManagerConverter(Converter):
             filepath = Path(url.path.strip("/"))
         base_path = filepath.parent
 
-        file_manager = FileManager(node["fileuris"],
-                                   node["target"],
-                                   node["datatype"],
-                                   node["shape"],
-                                   loader=AstropyFITSLoader,
-                                   basepath=base_path)
+        file_manager = FileManager.from_parts(node["fileuris"],
+                                              node["target"],
+                                              node["datatype"],
+                                              node["shape"],
+                                              loader=AstropyFITSLoader,
+                                              basepath=base_path)
         return file_manager
 
     def to_yaml_tree(self, obj, tag, ctx):
         node = {}
-        node["fileuris"] = obj._fileuris
-        node["target"] = obj.target
-        node["datatype"] = obj.dtype
-        node["shape"] = obj.shape
+        node["fileuris"] = obj._fits_loader._fileuris
+        node["target"] = obj._fits_loader.target
+        node["datatype"] = obj._fits_loader.dtype
+        node["shape"] = obj._fits_loader.shape
         return node

--- a/dkist/io/asdf/converters/file_manager.py
+++ b/dkist/io/asdf/converters/file_manager.py
@@ -34,8 +34,8 @@ class FileManagerConverter(Converter):
 
     def to_yaml_tree(self, obj, tag, ctx):
         node = {}
-        node["fileuris"] = obj._fits_loader._fileuris.tolist()
-        node["target"] = obj._fits_loader.target
-        node["datatype"] = obj._fits_loader.dtype
-        node["shape"] = obj._fits_loader.shape
+        node["fileuris"] = obj._striped_external_array._fileuris.tolist()
+        node["target"] = obj._striped_external_array.target
+        node["datatype"] = obj._striped_external_array.dtype
+        node["shape"] = obj._striped_external_array.shape
         return node

--- a/dkist/io/asdf/converters/file_manager.py
+++ b/dkist/io/asdf/converters/file_manager.py
@@ -34,7 +34,7 @@ class FileManagerConverter(Converter):
 
     def to_yaml_tree(self, obj, tag, ctx):
         node = {}
-        node["fileuris"] = obj._fits_loader._fileuris
+        node["fileuris"] = obj._fits_loader._fileuris.tolist()
         node["target"] = obj._fits_loader.target
         node["datatype"] = obj._fits_loader.dtype
         node["shape"] = obj._fits_loader.shape

--- a/dkist/io/asdf/tests/test_dataset.py
+++ b/dkist/io/asdf/tests/test_dataset.py
@@ -25,8 +25,8 @@ def tagobj(request):
 
 @pytest.fixture
 def file_manager():
-    return FileManager(['test1.fits', 'test2.fits'], 0, 'float', (10, 10),
-                       loader=AstropyFITSLoader)
+    return FileManager.from_parts(['test1.fits', 'test2.fits'], 0, 'float', (10, 10),
+                                  loader=AstropyFITSLoader)
 
 
 def test_roundtrip_file_manager(file_manager):

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -15,7 +15,7 @@ view into the original ``StripedExternalArray`` object through the
 ``StripedExternalArrayView`` class.
 """
 import os
-from typing import Any, Union, Iterable, Optional
+from typing import Any, List, Tuple, Union, Iterable, Optional
 from pathlib import Path
 
 import dask.array
@@ -52,7 +52,7 @@ class BaseStripedExternalArray:
         return all((uri, target, dtype, shape))
 
     @staticmethod
-    def _output_shape_from_ref_array(shape, reference_array) -> tuple[int]:
+    def _output_shape_from_ref_array(shape, reference_array) -> Tuple[int]:
         # If the first dimension is one we are going to squash it.
         if shape[0] == 1:
             shape = shape[1:]
@@ -63,7 +63,7 @@ class BaseStripedExternalArray:
             return tuple(list(reference_array.shape) + list(shape))
 
     @property
-    def output_shape(self) -> tuple[int, ...]:
+    def output_shape(self) -> Tuple[int, ...]:
         """
         The final shape of the reconstructed data array.
         """
@@ -150,7 +150,7 @@ class StripedExternalArray(BaseStripedExternalArray):
         """
         return self._loader_array
 
-    def _to_ears(self, urilist) -> list[ExternalArrayReference]:
+    def _to_ears(self, urilist) -> List[ExternalArrayReference]:
         # This is separate to the property because it's recursive
         if isinstance(urilist, (list, tuple)):
             return list(map(self._to_ears, urilist))

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -6,8 +6,8 @@ from asdf.tags.core.external_reference import ExternalArrayReference
 from astropy.wcs.wcsapi.wrappers.sliced_wcs import sanitize_slices
 
 from dkist.io.dask_utils import stack_loader_array
-from dkist.net.helpers import _orchestrate_transfer_task
 from dkist.net import conf as net_conf
+from dkist.net.helpers import _orchestrate_transfer_task
 
 
 class FITSLoader:

--- a/dkist/io/tests/test_file_manager.py
+++ b/dkist/io/tests/test_file_manager.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose
 import asdf
 
 from dkist.data.test import rootdir
-from dkist.io.file_manager import FileManager, FITSLoader, FITSLoaderView
+from dkist.io.file_manager import FileManager, StripedExternalArray, StripedExternalArrayView
 
 eitdir = Path(rootdir) / 'EIT'
 
@@ -70,11 +70,11 @@ def test_collection_to_references(tmpdir, file_manager):
 
 
 def test_collection_getitem(tmpdir, file_manager):
-    assert isinstance(file_manager._fits_loader, FITSLoader)
+    assert isinstance(file_manager._fits_loader, StripedExternalArray)
     assert isinstance(file_manager[0], FileManager)
-    assert isinstance(file_manager[0]._fits_loader, FITSLoaderView)
+    assert isinstance(file_manager[0]._fits_loader, StripedExternalArrayView)
     assert isinstance(file_manager[1], FileManager)
-    assert isinstance(file_manager[1]._fits_loader, FITSLoaderView)
+    assert isinstance(file_manager[1]._fits_loader, StripedExternalArrayView)
     assert len(file_manager[0]._fits_loader) == len(file_manager[1]._fits_loader) == 1
 
 
@@ -146,3 +146,18 @@ def test_file_manager_direct_slice(eit_dataset):
 
     sub_file.basepath = "test2"
     assert sub_file.basepath == ds.files.basepath
+
+
+def test_reprs(file_manager):
+    assert str(len(file_manager)) in repr(file_manager)
+    assert str(file_manager.shape) in repr(file_manager)
+
+    sea = file_manager._striped_external_array
+    assert str(len(sea)) in repr(sea)
+    assert str(sea.shape) in repr(sea)
+
+    sliced_file_manager = file_manager[4:6]
+    sliced_sea = sliced_file_manager._striped_external_array
+    assert str(len(sliced_sea)) in repr(sliced_sea)
+    assert str(sliced_sea.shape) in repr(sliced_sea)
+    assert str(sea) in repr(sliced_sea)

--- a/dkist/io/tests/test_file_manager.py
+++ b/dkist/io/tests/test_file_manager.py
@@ -8,7 +8,6 @@ from numpy.testing import assert_allclose
 import asdf
 
 from dkist.data.test import rootdir
-from dkist.io.file_manager import SlicedFileManagerProxy
 
 eitdir = Path(rootdir) / 'EIT'
 

--- a/dkist/io/tests/test_file_manager.py
+++ b/dkist/io/tests/test_file_manager.py
@@ -31,7 +31,7 @@ def externalarray(file_manager):
 
 def test_load_and_slicing(file_manager, externalarray):
     ext_shape = np.array(externalarray, dtype=object).shape
-    assert file_manager._fits_loader.loader_array.shape == ext_shape
+    assert file_manager._striped_external_array.loader_array.shape == ext_shape
     assert file_manager.output_shape == tuple(list(ext_shape) + [128, 128])
 
     array = file_manager._generate_array().compute()
@@ -41,7 +41,7 @@ def test_load_and_slicing(file_manager, externalarray):
 
     sliced_manager = file_manager[5:8]
     ext_shape = np.array(externalarray[5:8], dtype=object).shape
-    assert sliced_manager._fits_loader.loader_array.shape == ext_shape
+    assert sliced_manager._striped_external_array.loader_array.shape == ext_shape
     assert sliced_manager.output_shape == tuple(list(ext_shape) + [128, 128])
 
 
@@ -52,7 +52,7 @@ def test_filenames(file_manager, externalarray):
 
 def test_dask(file_manager, externalarray):
     ext_shape = np.array(externalarray, dtype=object).shape
-    assert file_manager._fits_loader.loader_array.shape == ext_shape
+    assert file_manager._striped_external_array.loader_array.shape == ext_shape
     assert file_manager.output_shape == tuple(list(ext_shape) + [128, 128])
 
     assert isinstance(file_manager._generate_array(), da.Array)
@@ -64,18 +64,18 @@ def test_collection_to_references(tmpdir, file_manager):
 
     for ear in ears:
         assert isinstance(ear, asdf.ExternalArrayReference)
-        assert ear.target == file_manager._fits_loader.target
-        assert ear.dtype == file_manager._fits_loader.dtype
-        assert ear.shape == file_manager._fits_loader.shape
+        assert ear.target == file_manager._striped_external_array.target
+        assert ear.dtype == file_manager._striped_external_array.dtype
+        assert ear.shape == file_manager._striped_external_array.shape
 
 
 def test_collection_getitem(tmpdir, file_manager):
-    assert isinstance(file_manager._fits_loader, StripedExternalArray)
+    assert isinstance(file_manager._striped_external_array, StripedExternalArray)
     assert isinstance(file_manager[0], FileManager)
-    assert isinstance(file_manager[0]._fits_loader, StripedExternalArrayView)
+    assert isinstance(file_manager[0]._striped_external_array, StripedExternalArrayView)
     assert isinstance(file_manager[1], FileManager)
-    assert isinstance(file_manager[1]._fits_loader, StripedExternalArrayView)
-    assert len(file_manager[0]._fits_loader) == len(file_manager[1]._fits_loader) == 1
+    assert isinstance(file_manager[1]._striped_external_array, StripedExternalArrayView)
+    assert len(file_manager[0]._striped_external_array) == len(file_manager[1]._striped_external_array) == 1
 
 
 def test_basepath_change(file_manager):

--- a/dkist/io/tests/test_fits.py
+++ b/dkist/io/tests/test_fits.py
@@ -40,7 +40,7 @@ def relative_ac(relative_ear):
 
 @pytest.fixture
 def relative_fl(relative_ac):
-    return relative_ac._fits_loader.loader_array.flat[0]
+    return relative_ac._striped_external_array.loader_array.flat[0]
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def absolute_ac(absolute_ear):
 
 @pytest.fixture
 def absolute_fl(absolute_ac):
-    return absolute_ac._fits_loader.loader_array.flat[0]
+    return absolute_ac._striped_external_array.loader_array.flat[0]
 
 
 def test_construct(relative_fl, absolute_fl):

--- a/dkist/io/tests/test_fits.py
+++ b/dkist/io/tests/test_fits.py
@@ -40,7 +40,7 @@ def relative_ac(relative_ear):
 
 @pytest.fixture
 def relative_fl(relative_ac):
-    return relative_ac._loader_array.flat[0]
+    return relative_ac._fits_loader.loader_array.flat[0]
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ def absolute_ac(absolute_ear):
 
 @pytest.fixture
 def absolute_fl(absolute_ac):
-    return absolute_ac._loader_array.flat[0]
+    return absolute_ac._fits_loader.loader_array.flat[0]
 
 
 def test_construct(relative_fl, absolute_fl):

--- a/dkist/io/tests/test_fits.py
+++ b/dkist/io/tests/test_fits.py
@@ -30,12 +30,12 @@ def absolute_ear():
 
 @pytest.fixture
 def relative_ac(relative_ear):
-    return FileManager([relative_ear.fileuri],
-                       relative_ear.target,
-                       relative_ear.dtype,
-                       relative_ear.shape,
-                       loader=AstropyFITSLoader,
-                       basepath=eitdir)
+    return FileManager.from_parts([relative_ear.fileuri],
+                                  relative_ear.target,
+                                  relative_ear.dtype,
+                                  relative_ear.shape,
+                                  loader=AstropyFITSLoader,
+                                  basepath=eitdir)
 
 
 @pytest.fixture
@@ -45,12 +45,12 @@ def relative_fl(relative_ac):
 
 @pytest.fixture
 def absolute_ac(absolute_ear):
-    return FileManager([absolute_ear.fileuri],
-                       absolute_ear.target,
-                       absolute_ear.dtype,
-                       absolute_ear.shape,
-                       loader=AstropyFITSLoader,
-                       basepath=eitdir)
+    return FileManager.from_parts([absolute_ear.fileuri],
+                                  absolute_ear.target,
+                                  absolute_ear.dtype,
+                                  absolute_ear.shape,
+                                  loader=AstropyFITSLoader,
+                                  basepath=eitdir)
 
 
 @pytest.fixture

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -1,11 +1,11 @@
-from typing import Any, Union, Iterable
+from typing import Union, Iterable
 
 import numpy as np
 
 try:
     from numpy.typing import ArrrayLike  # NOQA
 except ImportError:
-    ArrayLike = Any
+    ArrayLike = Iterable
 
 import astropy.modeling.models as m
 import astropy.units as u


### PR DESCRIPTION
This is an attempt to tidy up the API of `FileManager` in a way that makes it easy to apply many slices to the same underlying file manager object.

Fixes #166