### PR TITLE
Add a function to swap over axes of a dataset

### DIFF
--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -385,7 +385,8 @@ class FileManager(BaseFileManager):
         )
 
         if is_local:
-            local_destination = destination_path.expanduser().relative_to("/")
+            local_destination = destination_path.expanduser()
+            local_destination = local_destination.relative_to(local_destination.drive).relative_to("/")
             if local_destination.root == "":
                 local_destination = "/" / local_destination
-            self.basepath = local_destination
+            self.basepath = local_destination.absolute()

--- a/dkist/net/globus/transfer.py
+++ b/dkist/net/globus/transfer.py
@@ -10,8 +10,8 @@ from os import PathLike
 from typing import List, Union, Literal
 
 import globus_sdk
-from parfive.utils import in_notebook
-from tqdm import tqdm, tqdm_notebook
+from tqdm.auto import tqdm
+from tqdm.notebook import tqdm as tqdm_notebook
 
 from .endpoints import (auto_activate_endpoint, get_data_center_endpoint_id,
                         get_endpoint_id, get_local_endpoint_id, get_transfer_client)
@@ -170,14 +170,13 @@ def get_progress_bar(*args, **kwargs):  # pragma: no cover
     """
     Return the correct tqdm instance.
     """
-    notebook = in_notebook()
+    notebook = tqdm is tqdm_notebook
     if not notebook:
         kwargs['bar_format'] = '{l_bar}{bar}| {n_fmt}/{total_fmt} [{rate_fmt}{postfix}]'
     else:
         # TODO: Both having this and not having it breaks things.
         kwargs['total'] = kwargs.get("total", 1e9) or 1e9
-    the_tqdm = tqdm if not in_notebook() else tqdm_notebook
-    return the_tqdm(*args, **kwargs)
+    return tqdm(*args, **kwargs)
 
 
 def watch_transfer_progress(task_id, tfr_client, poll_interval=5,

--- a/dkist/processing/caveats.py
+++ b/dkist/processing/caveats.py
@@ -47,6 +47,7 @@ def swap_world_axes(dataset: dkist.Dataset, axis1: int, axis2: int) -> dkist.Dat
                                 meta=dataset.meta,
                                 unit=dataset.unit,
                                 copy=False)
-    new_dataset._file_manager = dataset._file_manager
+    if dataset._file_manager is not None:
+        new_dataset._file_manager = dataset._file_manager
 
     return new_dataset

--- a/dkist/processing/tests/test_caveats.py
+++ b/dkist/processing/tests/test_caveats.py
@@ -1,0 +1,6 @@
+from dkist.processing.caveats import swap_world_axes
+
+
+def test_swap_world_axes(dataset_4d):
+    new_ds = swap_world_axes(dataset_4d, 1, 2)
+    assert new_ds.wcs.world_axis_physical_types[1] == dataset_4d.wcs.world_axis_physical_types[2]

--- a/dkist/processing/tests/test_caveats.py
+++ b/dkist/processing/tests/test_caveats.py
@@ -1,6 +1,14 @@
+import pytest
+
+from ndcube.wcs.wrappers.reordered_wcs import ReorderedLowLevelWCS
+
 from dkist.processing.caveats import swap_world_axes
 
 
-def test_swap_world_axes(dataset_4d):
-    new_ds = swap_world_axes(dataset_4d, 1, 2)
-    assert new_ds.wcs.world_axis_physical_types[1] == dataset_4d.wcs.world_axis_physical_types[2]
+@pytest.mark.parametrize("dataset", ("dataset_4d", "eit_dataset"), indirect=True)
+def test_swap_world_axes(dataset):
+    new_ds = swap_world_axes(dataset, 0, 1)
+    assert new_ds.wcs.world_axis_physical_types[0] == dataset.wcs.world_axis_physical_types[1]
+
+    assert new_ds.files is dataset.files
+    assert isinstance(new_ds.wcs.low_level_wcs, ReorderedLowLevelWCS)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -25,6 +25,9 @@ Reference / API
 .. automodapi:: dkist.io.loaders
    :headings: #~
 
+.. automodapi:: dkist.processing.caveats
+   :headings: ^#
+
 .. automodapi:: dkist.wcs
    :headings: ^#
 

--- a/processing/caveats.py
+++ b/processing/caveats.py
@@ -1,0 +1,52 @@
+"""
+This module contains mitigation's for some known data caveats.
+"""
+from ndcube.wcs.wrappers.reordered_wcs import ReorderedLowLevelWCS
+
+import dkist
+
+
+def swap_world_axes(dataset: dkist.Dataset, axis1: int, axis2: int) -> dkist.Dataset:
+    """
+    This function swaps the position of two world axes.
+
+    Given a dataset and two world axes numbers (zero indexed) swap the positions of those two world axes in the dataset.
+
+    Parameters
+    ----------
+    dataset
+        The dataset to swap the world axes in.
+    axis1
+        The first world axis to swap
+    axis2
+        The second world axis to swap
+
+    Returns
+    -------
+    dataset
+        A new dataset object with an updated WCS with the world axes in a different order.
+
+    Notes
+    -----
+    This function changes the type ``.wcs`` property of the WCS from the
+    `gwcs.WCS` object to a
+    `~ndcube.wcs.wrappers.reordered_wcs.ReorderedLowLevelWCS` object.
+    """
+    world_order = list(range(dataset.wcs.world_n_dim))
+    new_world_order = list(range(dataset.wcs.world_n_dim))
+
+    new_world_order[axis1] = world_order[axis2]
+    new_world_order[axis2] = world_order[axis1]
+
+    pixel_order = list(range(dataset.wcs.pixel_n_dim))
+    new_wcs = ReorderedLowLevelWCS(dataset.wcs, pixel_order, new_world_order)
+    new_dataset = dkist.Dataset(dataset.data,
+                                wcs=new_wcs,
+                                uncertainty=dataset.uncertainty,
+                                mask=dataset.mask,
+                                meta=dataset.meta,
+                                unit=dataset.unit,
+                                copy=False)
+    new_dataset._file_manager = dataset._file_manager
+
+    return new_dataset

--- a/setup.cfg
+++ b/setup.cfg
@@ -116,6 +116,7 @@ filterwarnings =
     ignore:The distutils.sysconfig module is deprecated, use sysconfig instead:DeprecationWarning
     ignore:ASDF functionality for astropy is being moved out of the astropy package to the new asdf-astropy package
     ignore:FLIP_TOP_BOTTOM is deprecated and will be removed in Pillow.*
+    ignore::ResourceWarning
 
 [flake8]
 exclude = extern,sphinx,*parsetab.py,conftest.py,docs/conf.py,setup.py,__init__.py


### PR DESCRIPTION
This should help people to work with the data where the VISP has transposed the axes.

The general flow should be something like this:

```python

import dkist
from dkist.processing.caveats import swap_world_axes


ds = dkist.Dataset.from_asdf("path/to/file.asdf")
new_ds = swap_world_axes(ds, 1, 2)
```

I am going to try this out on an actual VISP dataset shortly