### PR TITLE
Fix reauth

### DIFF
--- a/changelog/197.bugfix.rst
+++ b/changelog/197.bugfix.rst
@@ -1,0 +1,1 @@
+Successfully ask for re-authentication when Globus token is stale.

--- a/dkist/net/globus/auth.py
+++ b/dkist/net/globus/auth.py
@@ -208,7 +208,7 @@ def ensure_globus_authorized(func):
         try:
             return func(*args, **kwargs)
         except globus_sdk.AuthAPIError as e:
-            if e.http_status == 400 and e.message == "invalid_grant":
+            if e.http_status == 400 and "invalid_grant" in e.message:
                 print("Globus login has expired.")
                 get_refresh_token_authorizer(force_reauth=True)
                 return func(*args, **kwargs)

--- a/dkist/net/globus/tests/test_auth.py
+++ b/dkist/net/globus/tests/test_auth.py
@@ -107,7 +107,7 @@ def test_get_refresh_token_authorizer(mocker):
 def test_ensure_auth_decorator(mocker):
     error = globus_sdk.AuthAPIError(mocker.MagicMock())
     mocker.patch.object(error, "http_status", 400)
-    mocker.patch.object(error, "message", "invalid_grant")
+    mocker.patch.object(error, "message", '{"error":"invalid_grant"}')
     reauth = mocker.patch("dkist.net.globus.auth.get_refresh_token_authorizer")
 
     called = [False]


### PR DESCRIPTION
Stale tokens were not triggering a re-authentication request due to a change in how the message was delivered from Globus. This fixes that (and fixes #179 )