### PR TITLE
Fix bad labels

### DIFF
--- a/changelog/200.bugfix.rst
+++ b/changelog/200.bugfix.rst
@@ -1,0 +1,1 @@
+No more invalid characters in default Globus label name.

--- a/dkist/net/globus/transfer.py
+++ b/dkist/net/globus/transfer.py
@@ -80,7 +80,7 @@ def start_transfer_from_file_list(src_endpoint, dst_endpoint, dst_base_path, fil
     dst_endpoint = get_endpoint_id(dst_endpoint, tc)
     auto_activate_endpoint(dst_endpoint, tc)
 
-    now = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M")
+    now = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M")
     label = f"DKIST Python Tools - {now}" if label is None else label
     transfer_manifest = globus_sdk.TransferData(tc, src_endpoint, dst_endpoint,
                                                 label=label,

--- a/dkist/net/helpers.py
+++ b/dkist/net/helpers.py
@@ -104,7 +104,7 @@ def transfer_complete_datasets(datasets: Union[str, QueryResponseRow, DKISTQuery
         bucket=bucket
     ))]
 
-    now = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M")
+    now = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M")
     label = f"DKIST Python Tools - {now} {dataset_id}" if label is None else label
 
     _orchestrate_transfer_task(file_list,

--- a/dkist/net/tests/test_helpers.py
+++ b/dkist/net/tests/test_helpers.py
@@ -35,7 +35,7 @@ def test_download_default_keywords(orchestrate_transfer_mock, keywords):
     )
 
     if keywords["label"] is None:
-        keywords["label"] = f"DKIST Python Tools - {datetime.datetime.now().strftime('%Y-%m-%dT%H:%M')} AAAA"
+        keywords["label"] = f"DKIST Python Tools - {datetime.datetime.now().strftime('%Y-%m-%dT%H-%M')} AAAA"
     orchestrate_transfer_mock.assert_called_once_with(
         [Path("/data/pm_1_10/AAAA")],
         recursive=True,
@@ -66,7 +66,7 @@ def test_transfer_from_dataset_id(mocker, orchestrate_transfer_mock):
         destination_endpoint=None,
         progress=True,
         wait=True,
-        label=f"DKIST Python Tools - {datetime.datetime.now().strftime('%Y-%m-%dT%H:%M')} AAAA"
+        label=f"DKIST Python Tools - {datetime.datetime.now().strftime('%Y-%m-%dT%H-%M')} AAAA"
     )
 
     get_inv_mock.assert_called_once_with("AAAA")


### PR DESCRIPTION
Default labels had ":" characters, which Globus doesn't like. Remove them.

Fixes #195 