### PR TITLE
Manage empty searches in `transfer_complete_datasets`

### DIFF
--- a/changelog/204.bugfix.rst
+++ b/changelog/204.bugfix.rst
@@ -1,0 +1,1 @@
+Catch empty return value from data search in `transfer_complete_datasets` and raise a ValueError telling the user what's happening.

--- a/dkist/data/test/small_visp/test_visp.asdf
+++ b/dkist/data/test/small_visp/test_visp.asdf
@@ -25,11 +25,11 @@ history:
   - !core/extension_metadata-1.0.0
     extension_class: asdf.extension._manifest.ManifestExtension
     extension_uri: asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.0.0
-    software: !core/software-1.0.0 {name: gwcs, version: 0.18.2a1.dev4+g6ec3954.d20220429}
+    software: !core/software-1.0.0 {name: gwcs, version: 0.18.2a1}
   - !core/extension_metadata-1.0.0
     extension_class: asdf.extension._manifest.ManifestExtension
     extension_uri: asdf://dkist.nso.edu/dkist/extensions/dkist-1.0.0
-    software: !core/software-1.0.0 {name: dkist, version: 1.0.0b9.dev4+gfdb77e4}
+    software: !core/software-1.0.0 {name: dkist, version: 1.0.0b8}
   - !core/extension_metadata-1.0.0
     extension_class: asdf.extension._manifest.ManifestExtension
     extension_uri: asdf://astropy.org/astropy/extensions/astropy-1.0.0

--- a/dkist/net/helpers.py
+++ b/dkist/net/helpers.py
@@ -70,7 +70,10 @@ def transfer_complete_datasets(datasets: Union[str, QueryResponseRow, DKISTQuery
     from dkist.net import conf
 
     if isinstance(datasets, str):
-        datasets = _get_dataset_inventory(datasets)[0]
+        try:
+            datasets = _get_dataset_inventory(datasets)[0]
+        except IndexError as e:
+            raise IndexError(f"No results available for dataset {datasets}") from e
 
     # If we have a UnifiedResponse object, it could contain one or more dkist tables.
     # Stack them and then treat them like we were passed a single table with many rows.

--- a/dkist/net/helpers.py
+++ b/dkist/net/helpers.py
@@ -22,7 +22,7 @@ def _get_dataset_inventory(dataset_id: str):  # pragma: no cover
     Do a search for a single dataset id
     """
     results = DKISTClient().search(Dataset(dataset_id))
-    if len(results) == 1:
+    if len(results) == 0:
         raise IndexError(f"No results available for dataset {dataset_id}")
 
     return results

--- a/dkist/net/helpers.py
+++ b/dkist/net/helpers.py
@@ -21,7 +21,11 @@ def _get_dataset_inventory(dataset_id: str):  # pragma: no cover
     """
     Do a search for a single dataset id
     """
-    return DKISTClient().search(Dataset(dataset_id))
+    results = DKISTClient().search(Dataset(dataset_id))
+    if len(results) == 1:
+        raise IndexError(f"No results available for dataset {dataset_id}")
+
+    return results
 
 
 def transfer_complete_datasets(datasets: Union[str, QueryResponseRow, DKISTQueryResponseTable, UnifiedResponse],
@@ -70,10 +74,7 @@ def transfer_complete_datasets(datasets: Union[str, QueryResponseRow, DKISTQuery
     from dkist.net import conf
 
     if isinstance(datasets, str):
-        try:
-            datasets = _get_dataset_inventory(datasets)[0]
-        except IndexError as e:
-            raise IndexError(f"No results available for dataset {datasets}") from e
+        datasets = _get_dataset_inventory(datasets)[0]
 
     # If we have a UnifiedResponse object, it could contain one or more dkist tables.
     # Stack them and then treat them like we were passed a single table with many rows.

--- a/dkist/net/helpers.py
+++ b/dkist/net/helpers.py
@@ -23,7 +23,7 @@ def _get_dataset_inventory(dataset_id: str):  # pragma: no cover
     """
     results = DKISTClient().search(Dataset(dataset_id))
     if len(results) == 0:
-        raise IndexError(f"No results available for dataset {dataset_id}")
+        raise ValueError(f"No results available for dataset {dataset_id}")
 
     return results
 

--- a/dkist/net/tests/test_helpers.py
+++ b/dkist/net/tests/test_helpers.py
@@ -51,7 +51,7 @@ def test_transfer_unavailable_data(mocker):
         return_value=[],
     )
 
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         transfer_complete_datasets("null")
 
 

--- a/dkist/net/tests/test_helpers.py
+++ b/dkist/net/tests/test_helpers.py
@@ -51,7 +51,7 @@ def test_transfer_unavailable_data(mocker):
         return_value=[],
     )
 
-    with pytest.raises(ValueError, "No results available for dataset"):
+    with pytest.raises(ValueError, match="No results available for dataset"):
         transfer_complete_datasets("null")
 
 

--- a/dkist/net/tests/test_helpers.py
+++ b/dkist/net/tests/test_helpers.py
@@ -44,6 +44,17 @@ def test_download_default_keywords(orchestrate_transfer_mock, keywords):
     )
 
 
+def test_transfer_unavailable_data(mocker):
+    get_inv_mock = mocker.patch(
+        "dkist.net.helpers._get_dataset_inventory",
+        autospec=True,
+        return_value=[],
+    )
+
+    with pytest.raises(IndexError):
+        transfer_complete_datasets("null")
+
+
 def test_transfer_from_dataset_id(mocker, orchestrate_transfer_mock):
     get_inv_mock = mocker.patch(
         "dkist.net.helpers._get_dataset_inventory",

--- a/dkist/net/tests/test_helpers.py
+++ b/dkist/net/tests/test_helpers.py
@@ -46,7 +46,7 @@ def test_download_default_keywords(orchestrate_transfer_mock, keywords):
 
 def test_transfer_unavailable_data(mocker):
     get_inv_mock = mocker.patch(
-        "dkist.net.helpers._get_dataset_inventory",
+        "dkist.net.client.DKISTClient.search",
         autospec=True,
         return_value=[],
     )

--- a/dkist/net/tests/test_helpers.py
+++ b/dkist/net/tests/test_helpers.py
@@ -51,7 +51,7 @@ def test_transfer_unavailable_data(mocker):
         return_value=[],
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, "No results available for dataset"):
         transfer_complete_datasets("null")
 
 


### PR DESCRIPTION
Closes #194

In `transfer_complete_datasets`, if `_get_dataset_inventory` returns no results (which it might if the ID string is invalid or if the data just aren't available), this catches the error and raises it with an appropriate message.