### PR TITLE
Ravel model for the illusion of 2D tables

### DIFF
--- a/changelog/227.bugfix.rst
+++ b/changelog/227.bugfix.rst
@@ -1,3 +1,2 @@
 Add a new model to take a 2D index and return the corresponding correct index for a 1D array, and the inverse model for the reverse operation.
 To be used as a compound with Tabular1D so that it looks like a Tabular2D but the compound model can still be inverted.
-This will be relevant and useful in the dkist-inventory package but users are unlikely to need to use it.

--- a/changelog/227.bugfix.rst
+++ b/changelog/227.bugfix.rst
@@ -1,0 +1,3 @@
+Add a new model to take a 2D index and return the corresponding correct index for a 1D array, and the inverse model for the reverse operation.
+To be used as a compound with Tabular1D so that it looks like a Tabular2D but the compound model can still be inverted.
+This will be relevant and useful in the dkist-inventory package but users are unlikely to need to use it.

--- a/dkist/io/asdf/converters/__init__.py
+++ b/dkist/io/asdf/converters/__init__.py
@@ -1,4 +1,4 @@
 from .dataset import DatasetConverter
 from .file_manager import FileManagerConverter
-from .models import CoupledCompoundConverter, VaryingCelestialConverter
+from .models import CoupledCompoundConverter, VaryingCelestialConverter, RavelConverter
 from .tiled_dataset import TiledDatasetConverter

--- a/dkist/io/asdf/converters/__init__.py
+++ b/dkist/io/asdf/converters/__init__.py
@@ -1,4 +1,4 @@
 from .dataset import DatasetConverter
 from .file_manager import FileManagerConverter
-from .models import CoupledCompoundConverter, VaryingCelestialConverter, RavelConverter
+from .models import CoupledCompoundConverter, RavelConverter, VaryingCelestialConverter
 from .tiled_dataset import TiledDatasetConverter

--- a/dkist/io/asdf/converters/models.py
+++ b/dkist/io/asdf/converters/models.py
@@ -129,7 +129,7 @@ class RavelModel(TransformConverterBase):
     types = ["dkist.wcs.models.Ravel"]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
-        return {"array_shape": self.array_shape}
+        return {"array_shape": model.array_shape}
 
     def from_yaml_tree_transform(self, node, tag, ctx):
         from dkist.wcs.models import Ravel

--- a/dkist/io/asdf/converters/models.py
+++ b/dkist/io/asdf/converters/models.py
@@ -123,7 +123,7 @@ class RavelConverter(TransformConverterBase):
     """
 
     tags  = [
-        "asdf://dkist.nso.edu/tags/ravel_model-1.0.0.yaml"
+        "asdf://dkist.nso.edu/tags/ravel_model-1.0.0"
     ]
 
     types = ["dkist.wcs.models.Ravel"]

--- a/dkist/io/asdf/converters/models.py
+++ b/dkist/io/asdf/converters/models.py
@@ -129,9 +129,9 @@ class RavelConverter(TransformConverterBase):
     types = ["dkist.wcs.models.Ravel"]
 
     def to_yaml_tree_transform(self, model, tag, ctx):
-        return {"array_shape": model.array_shape}
+        return {"array_shape": model.array_shape, "order": model.order}
 
     def from_yaml_tree_transform(self, node, tag, ctx):
         from dkist.wcs.models import Ravel
 
-        return Ravel(node["array_shape"])
+        return Ravel(node["array_shape"], order=node["order"])

--- a/dkist/io/asdf/converters/models.py
+++ b/dkist/io/asdf/converters/models.py
@@ -115,3 +115,23 @@ class CoupledCompoundConverter(TransformConverterBase):
                                      shared_inputs=node["shared_inputs"])
 
         return model
+
+
+class RavelModel(TransformConverterBase):
+    """
+    ASDF serialization support for Ravel
+    """
+
+    tags  = [
+        "asdf://dkist.nso.edu/tags/ravel_model-1.0.0.yaml"
+    ]
+
+    types = ["dkist.wcs.models.Ravel"]
+
+    def to_yaml_tree_transform(self, model, tag, ctx):
+        return {"array_shape": self.array_shape}
+
+    def from_yaml_tree_transform(self, node, tag, ctx):
+        from dkist.wcs.models import Ravel
+
+        return Ravel(node["array_shape"])

--- a/dkist/io/asdf/converters/models.py
+++ b/dkist/io/asdf/converters/models.py
@@ -117,7 +117,7 @@ class CoupledCompoundConverter(TransformConverterBase):
         return model
 
 
-class RavelModel(TransformConverterBase):
+class RavelConverter(TransformConverterBase):
     """
     ASDF serialization support for Ravel
     """

--- a/dkist/io/asdf/entry_points.py
+++ b/dkist/io/asdf/entry_points.py
@@ -50,6 +50,8 @@ def get_extensions():
                                    converters=dkist_converters),
         ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-wcs-1.1.0",
                                    converters=wcs_converters),
+        ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-wcs-1.0.0",
+                                   converters=wcs_converters),
         # This manifest handles all pre-refactor tags
         ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-0.9.0",
                                    converters=dkist_converters,

--- a/dkist/io/asdf/entry_points.py
+++ b/dkist/io/asdf/entry_points.py
@@ -48,7 +48,7 @@ def get_extensions():
                                    converters=dkist_converters),
         ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-1.0.0",
                                    converters=dkist_converters),
-        ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-wcs-1.0.0",
+        ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-wcs-1.1.0",
                                    converters=wcs_converters),
         # This manifest handles all pre-refactor tags
         ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-0.9.0",

--- a/dkist/io/asdf/entry_points.py
+++ b/dkist/io/asdf/entry_points.py
@@ -13,7 +13,7 @@ else:
 
 from dkist.io.asdf.converters import (CoupledCompoundConverter, DatasetConverter,
                                       FileManagerConverter, TiledDatasetConverter,
-                                      VaryingCelestialConverter)
+                                      VaryingCelestialConverter, RavelConverter)
 
 
 def get_resource_mappings():
@@ -42,7 +42,7 @@ def get_extensions():
     Get the list of extensions.
     """
     dkist_converters = [FileManagerConverter(), DatasetConverter(), TiledDatasetConverter()]
-    wcs_converters = [VaryingCelestialConverter(), CoupledCompoundConverter()]
+    wcs_converters = [VaryingCelestialConverter(), CoupledCompoundConverter(), RavelConverter()]
     return [
         ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-1.1.0",
                                    converters=dkist_converters),

--- a/dkist/io/asdf/entry_points.py
+++ b/dkist/io/asdf/entry_points.py
@@ -6,14 +6,15 @@ import sys
 from asdf.extension import ManifestExtension
 from asdf.resource import DirectoryResourceMapping
 
+from dkist.io.asdf.converters import (CoupledCompoundConverter, DatasetConverter,
+                                      FileManagerConverter, RavelConverter, TiledDatasetConverter,
+                                      VaryingCelestialConverter)
+
 if sys.version_info < (3, 9):
     import importlib_resources
 else:
     import importlib.resources as importlib_resources
 
-from dkist.io.asdf.converters import (CoupledCompoundConverter, DatasetConverter,
-                                      FileManagerConverter, TiledDatasetConverter,
-                                      VaryingCelestialConverter, RavelConverter)
 
 
 def get_resource_mappings():

--- a/dkist/io/asdf/resources/manifests/dkist-wcs-1.1.0.yaml
+++ b/dkist/io/asdf/resources/manifests/dkist-wcs-1.1.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
-id: asdf://dkist.nso.edu/dkist/manifests/dkist-wcs-1.0.0
-extension_uri: asdf://dkist.nso.edu/dkist/extensions/dkist-wcs-1.0.0
+id: asdf://dkist.nso.edu/dkist/manifests/dkist-wcs-1.1.0
+extension_uri: asdf://dkist.nso.edu/dkist/extensions/dkist-wcs-1.1.0
 title: DKIST WCS extension
 description: ASDF schemas and tags for models and WCS related classes.
 

--- a/dkist/io/asdf/resources/manifests/dkist-wcs-1.1.0.yaml
+++ b/dkist/io/asdf/resources/manifests/dkist-wcs-1.1.0.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+id: asdf://dkist.nso.edu/dkist/manifests/dkist-wcs-1.0.0
+extension_uri: asdf://dkist.nso.edu/dkist/extensions/dkist-wcs-1.0.0
+title: DKIST WCS extension
+description: ASDF schemas and tags for models and WCS related classes.
+
+tags:
+  - schema_uri: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.0.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/varying_celestial_transform-1.0.0"
+  - schema_uri: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.0.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform-1.0.0"
+  - schema_uri: "asdf://dkist.nso.edu/schemas/coupled_compound_model-1.0.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/coupled_compound_model-1.0.0"
+  - schema_uri: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.0.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/varying_celestial_transform_slit-1.0.0"
+  - schema_uri: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.0.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform_slit-1.0.0"
+  - schema_uri: "asdf://dkist.nso.edu/schemas/ravel_model-1.0.0.yaml"
+    tag_uri: "asdf://dkist.nso.edu/tags/ravel_model-1.0.0.yaml"

--- a/dkist/io/asdf/resources/manifests/dkist-wcs-1.1.0.yaml
+++ b/dkist/io/asdf/resources/manifests/dkist-wcs-1.1.0.yaml
@@ -16,5 +16,5 @@ tags:
     tag_uri: "asdf://dkist.nso.edu/tags/varying_celestial_transform_slit-1.0.0"
   - schema_uri: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.0.0"
     tag_uri: "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform_slit-1.0.0"
-  - schema_uri: "asdf://dkist.nso.edu/schemas/ravel_model-1.0.0.yaml"
-    tag_uri: "asdf://dkist.nso.edu/tags/ravel_model-1.0.0.yaml"
+  - schema_uri: "asdf://dkist.nso.edu/schemas/ravel_model-1.0.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/ravel_model-1.0.0"

--- a/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
+++ b/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
@@ -10,5 +10,5 @@ description:
 type: object
 properties:
   array_shape:
-    type: tuple
+    type: array
   required: array_shape

--- a/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
+++ b/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
@@ -11,4 +11,4 @@ type: object
 properties:
   array_shape:
     type: array
-required: array_shape
+required: [array_shape]

--- a/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
+++ b/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "asdf://dkist.nso.edu/schemas/ravel-model-1.0.0"
+id: "asdf://dkist.nso.edu/schemas/ravel_model-1.0.0"
 
 title: A model to flatten 2D indices into 1D
 description:

--- a/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
+++ b/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://dkist.nso.edu/schemas/ravel-model-1.0.0"
+
+title: A model to flatten 2D indices into 1D
+description:
+  A model which takes a pair of indices and flattens them into the corresponding index for a 1D array. This can be used as a compound with Tabular1D to enable it to be indexed as if it were Tabular2D.
+
+type: object
+properties:
+  array_shape:
+    type: tuple
+  required: array_shape

--- a/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
+++ b/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
@@ -11,4 +11,6 @@ type: object
 properties:
   array_shape:
     type: array
-required: [array_shape]
+  order:
+    type: string
+required: [array_shape, order]

--- a/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
+++ b/dkist/io/asdf/resources/schemas/ravel_model-1.0.0.yaml
@@ -11,4 +11,4 @@ type: object
 properties:
   array_shape:
     type: array
-  required: array_shape
+required: array_shape

--- a/dkist/io/asdf/tests/test_models.py
+++ b/dkist/io/asdf/tests/test_models.py
@@ -11,7 +11,7 @@ from dkist.wcs.models import (CoupledCompoundModel, InverseVaryingCelestialTrans
                               InverseVaryingCelestialTransformSlit,
                               InverseVaryingCelestialTransformSlit2D, VaryingCelestialTransform,
                               VaryingCelestialTransform2D, VaryingCelestialTransformSlit,
-                              VaryingCelestialTransformSlit2D)
+                              VaryingCelestialTransformSlit2D, Ravel, Unravel)
 
 
 def test_roundtrip_vct():
@@ -122,3 +122,13 @@ def test_coupled_compound_model_nested():
 
     assert ccm.n_inputs == new.n_inputs
     assert ccm.inputs == new.inputs
+
+
+def test_ravel_model():
+    ravel = Ravel((10, 10))
+    new = roundtrip_object(ravel)
+
+    assert isinstance(new, Ravel)
+    assert isinstance(new.inverse, Unravel)
+
+    assert new.array_shape == ravel.array_shape

--- a/dkist/io/asdf/tests/test_models.py
+++ b/dkist/io/asdf/tests/test_models.py
@@ -9,9 +9,9 @@ from astropy.modeling import CompoundModel
 from dkist.wcs.models import (CoupledCompoundModel, InverseVaryingCelestialTransform,
                               InverseVaryingCelestialTransform2D,
                               InverseVaryingCelestialTransformSlit,
-                              InverseVaryingCelestialTransformSlit2D, VaryingCelestialTransform,
-                              VaryingCelestialTransform2D, VaryingCelestialTransformSlit,
-                              VaryingCelestialTransformSlit2D, Ravel, Unravel)
+                              InverseVaryingCelestialTransformSlit2D, Ravel, Unravel,
+                              VaryingCelestialTransform, VaryingCelestialTransform2D,
+                              VaryingCelestialTransformSlit, VaryingCelestialTransformSlit2D)
 
 
 def test_roundtrip_vct():

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -747,7 +747,7 @@ class Ravel(Model):
         self.array_shape = array_shape
 
     def evaluate(self, *inputs):
-        return (inputs[0] * self.array_shape[1]) + inputs[1]
+        return (np.round(inputs[0]) * self.array_shape[1]) + inputs[1]
 
     @property
     def inverse(self):

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Union
+from typing import Union, Iterable
 
 import numpy as np
 

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -767,6 +767,7 @@ class Unravel(Model):
     array_shape = (0, 0)
     n_inputs = 1
     n_outputs = 2
+    _separable = False
 
     def __init__(self, array_shape, order='C', **kwargs):
         super().__init__(**kwargs)

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -740,6 +740,7 @@ class Ravel(Model):
     array_shape = (0, 0)
     n_inputs = 2
     n_outputs = 1
+    _separable = False
 
     def __init__(self, array_shape, **kwargs):
         super().__init__(**kwargs)

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -745,7 +745,7 @@ class Ravel(Model):
     def __init__(self, array_shape, **kwargs):
         super().__init__(**kwargs)
 
-        self.array_shape = array_shape
+        self.array_shape = tuple(array_shape)
 
     def evaluate(self, *inputs):
         return (np.round(inputs[0]) * self.array_shape[1]) + inputs[1]

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -751,8 +751,7 @@ class Ravel(Model):
 
     @property
     def inverse(self):
-        unravel = unravel_model()
-        return unravel(self.array_shape)
+        return Unravel(self.array_shape)
 
 
 class Unravel(Model):
@@ -770,5 +769,4 @@ class Unravel(Model):
 
     @property
     def inverse(self):
-        ravel = ravel_model()
-        return ravel(self.array_shape)
+        return Ravel(self.array_shape)

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -746,7 +746,9 @@ class Ravel(Model):
         super().__init__(**kwargs)
 
         self.array_shape = tuple(array_shape)
-        self.order = order  # TODO: Validate order is either C or F
+        if order not in ("C", "F"):
+            raise ValueError("order kwarg must be one of 'C' or 'F'")
+        self.order = order
 
     def evaluate(self, *inputs):
         ravel_shape = self.array_shape[1]
@@ -773,7 +775,9 @@ class Unravel(Model):
         super().__init__(**kwargs)
 
         self.array_shape = array_shape
-        self.order = order  # TODO: Validate order is either C or F
+        if order not in ("C", "F"):
+            raise ValueError("order kwarg must be one of 'C' or 'F'")
+        self.order = order
 
     def evaluate(self, input_):
         i = 1 if self.order == 'C' else 0

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -2,15 +2,14 @@ from typing import Iterable, Union
 
 import numpy as np
 
-import astropy.modeling.models as m
-import astropy.units as u
-from astropy.modeling import CompoundModel, Model, Parameter, separable
-
 try:
     from numpy.typing import ArrrayLike  # NOQA
 except ImportError:
     ArrayLike = Iterable
 
+import astropy.modeling.models as m
+import astropy.units as u
+from astropy.modeling import CompoundModel, Model, Parameter, separable
 
 __all__ = ['CoupledCompoundModel',
            'InverseVaryingCelestialTransform',

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -1,8 +1,9 @@
 from typing import Iterable, Union
 
+import numpy as np
+
 import astropy.modeling.models as m
 import astropy.units as u
-import numpy as np
 from astropy.modeling import CompoundModel, Model, Parameter, separable
 
 try:

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -15,7 +15,7 @@ __all__ = ['CoupledCompoundModel',
            'InverseVaryingCelestialTransform',
            'VaryingCelestialTransform',
            'BaseVaryingCelestialTransform',
-           'RavelModel']
+           'Ravel']
 
 
 def generate_celestial_transform(crpix: Union[Iterable[float], u.Quantity],

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -410,3 +410,18 @@ def test_raveled_tabular1d(array_shape):
         assert raveled_tab(x, y) == expected_val
         assert np.allclose(raveled_tab.inverse(expected_val), (round(x), y))
         assert raveled_tab.inverse.inverse(x, y) == expected_val
+
+
+@pytest.mark.parametrize("array_shape",
+                         [(i, 100 // i) for i in range(2, 21)])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_ravel_ordering(array_shape, order):
+    ravel = Ravel(array_shape, order=order)
+
+    values = np.arange(array_shape[0]*array_shape[1]).reshape(array_shape, order=order)
+
+    # Make 10 attempts with random numbers
+    for _ in range(10):
+        x, y = (np.random.randint((array_shape[0]-1)),
+                np.random.randint((array_shape[1]-1)))
+        assert ravel(x, y) == values[x, y]

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -371,3 +371,17 @@ def test_vct_slit2d_unitless():
     world = vct_slit(*pixel)
     ipixel = vct_slit.inverse(*world, 0, 0)
     assert u.allclose(ipixel, pixel[0], atol=1e-5)
+
+
+def test_ravel_model():
+    shape = (20, 5)
+    ravel = Ravel(shape)
+
+    assert ravel(15, 3) == 78
+
+
+def test_unravel_model():
+    shape = (20, 5)
+    unravel = Unravel(shape)
+
+    assert unravel(78) == (15, 3)

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -6,9 +6,9 @@ import astropy.units as u
 from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.modeling import CompoundModel
 
-from dkist.wcs.models import (VaryingCelestialTransform, VaryingCelestialTransform2D,
-                              VaryingCelestialTransformSlit, VaryingCelestialTransformSlit2D,
-                              generate_celestial_transform,
+from dkist.wcs.models import (Ravel, VaryingCelestialTransform,
+                              VaryingCelestialTransform2D, VaryingCelestialTransformSlit,
+                              VaryingCelestialTransformSlit2D, generate_celestial_transform,
                               varying_celestial_transform_from_tables)
 
 
@@ -379,9 +379,6 @@ def test_ravel_model():
 
     assert ravel(15, 3) == 78
 
+    assert ravel.inverse(78) == (15, 3)
 
-def test_unravel_model():
-    shape = (20, 5)
-    unravel = Unravel(shape)
-
-    assert unravel(78) == (15, 3)
+    assert ravel.inverse.inverse(15, 3) == 78

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -7,9 +7,9 @@ from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.modeling import CompoundModel
 from astropy.modeling.models import Tabular1D
 
-from dkist.wcs.models import (Ravel, VaryingCelestialTransform,
-                              VaryingCelestialTransform2D, VaryingCelestialTransformSlit,
-                              VaryingCelestialTransformSlit2D, generate_celestial_transform,
+from dkist.wcs.models import (Ravel, VaryingCelestialTransform, VaryingCelestialTransform2D,
+                              VaryingCelestialTransformSlit, VaryingCelestialTransformSlit2D,
+                              generate_celestial_transform,
                               varying_celestial_transform_from_tables)
 
 

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -391,7 +391,6 @@ def test_ravel_model(array_shape):
 @pytest.mark.parametrize("array_shape",
                          [(i, 100 // i) for i in range(2, 21)])
 def test_raveled_tabular1d(array_shape):
-    print(array_shape)
     values = np.arange(100)
 
     ravel = Ravel(array_shape)

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -425,3 +425,14 @@ def test_ravel_ordering(array_shape, order):
         x, y = (np.random.randint((array_shape[0]-1)),
                 np.random.randint((array_shape[1]-1)))
         assert ravel(x, y) == values[x, y]
+
+
+@pytest.mark.parametrize("array_shape",
+                         [(i, 100 // i) for i in range(2, 21)])
+@pytest.mark.parametrize("order", ["C", "F"])
+def test_ravel_repr(array_shape, order):
+    ravel = Ravel(array_shape, order=order)
+    unravel = ravel.inverse
+
+    assert str(array_shape) in repr(ravel) and order in repr(ravel)
+    assert str(array_shape) in repr(unravel) and order in repr(unravel)


### PR DESCRIPTION
Closes #168 (once dkist-inventory is updated to use these changes).

Adds a new model to take a 2D index and return the corresponding correct index for a 1D array, and the inverse model for the reverse operation. To be used as a compound with `Tabular1D` so that it looks like a `Tabular2D` but the compound model can still be inverted.

Should be straightforward to expand to 3D also.