### PR TITLE
Varying celestial transforms 3 d

### DIFF
--- a/changelog/277.feature.rst
+++ b/changelog/277.feature.rst
@@ -1,0 +1,1 @@
+Add experimental support for 3D LUTs to TimeVaryingCelestialTransform

--- a/dkist/io/asdf/converters/models.py
+++ b/dkist/io/asdf/converters/models.py
@@ -13,29 +13,55 @@ class VaryingCelestialConverter(TransformConverterBase):
         "dkist.wcs.models.InverseVaryingCelestialTransform",
         "dkist.wcs.models.VaryingCelestialTransform2D",
         "dkist.wcs.models.InverseVaryingCelestialTransform2D",
+        "dkist.wcs.models.VaryingCelestialTransform3D",
+        "dkist.wcs.models.InverseVaryingCelestialTransform3D",
         "dkist.wcs.models.VaryingCelestialTransformSlit",
         "dkist.wcs.models.InverseVaryingCelestialTransformSlit",
         "dkist.wcs.models.VaryingCelestialTransformSlit2D",
         "dkist.wcs.models.InverseVaryingCelestialTransformSlit2D",
+        "dkist.wcs.models.VaryingCelestialTransformSlit3D",
+        "dkist.wcs.models.InverseVaryingCelestialTransformSlit3D",
     ]
 
     def select_tag(self, obj, tags, ctx):
         from dkist.wcs.models import (InverseVaryingCelestialTransform,
                                       InverseVaryingCelestialTransform2D,
+                                      InverseVaryingCelestialTransform3D,
                                       InverseVaryingCelestialTransformSlit,
                                       InverseVaryingCelestialTransformSlit2D,
+                                      InverseVaryingCelestialTransformSlit3D,
                                       VaryingCelestialTransform, VaryingCelestialTransform2D,
-                                      VaryingCelestialTransformSlit,
-                                      VaryingCelestialTransformSlit2D)
+                                      VaryingCelestialTransform3D, VaryingCelestialTransformSlit,
+                                      VaryingCelestialTransformSlit2D,
+                                      VaryingCelestialTransformSlit3D)
 
-        if isinstance(obj, (VaryingCelestialTransform, VaryingCelestialTransform2D)):
+        if isinstance(
+                obj,
+                (VaryingCelestialTransform,
+                 VaryingCelestialTransform2D,
+                 VaryingCelestialTransform3D)
+        ):
             return "asdf://dkist.nso.edu/tags/varying_celestial_transform-1.0.0"
-        elif isinstance(obj, (InverseVaryingCelestialTransform, InverseVaryingCelestialTransform2D)):
+        elif isinstance(
+                obj,
+                (InverseVaryingCelestialTransform,
+                 InverseVaryingCelestialTransform2D,
+                 InverseVaryingCelestialTransform3D)
+        ):
             return "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform-1.0.0"
-        elif isinstance(obj, (VaryingCelestialTransformSlit, VaryingCelestialTransformSlit2D)):
+        elif isinstance(
+                obj,
+                (VaryingCelestialTransformSlit,
+                 VaryingCelestialTransformSlit2D,
+                 VaryingCelestialTransformSlit3D)
+        ):
             return "asdf://dkist.nso.edu/tags/varying_celestial_transform_slit-1.0.0"
-        elif isinstance(obj, (InverseVaryingCelestialTransformSlit,
-                              InverseVaryingCelestialTransformSlit2D)):
+        elif isinstance(
+                obj,
+                (InverseVaryingCelestialTransformSlit,
+                 InverseVaryingCelestialTransformSlit2D,
+                 InverseVaryingCelestialTransformSlit3D)
+                 ):
             return "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform_slit-1.0.0"
         else:
             raise ValueError(f"Unsupported object: {obj}")  # pragma: no cover

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -952,7 +952,7 @@ def varying_celestial_transform_from_tables(
         crval_table,
     )
     if (table_d := len(table_shape)) not in range(1, 4):
-        raise ValueError("Only one or two dimensional lookup tables are supported.")
+        raise ValueError("Only 1D, 2D and 3D lookup tables are supported.")
 
     cls = varying_celestial_transform_dict[(slit, table_d, inverse)]
     return cls(

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -465,7 +465,7 @@ class VaryingCelestialTransform3D(BaseVaryingCelestialTransform3D):
 
     @property
     def inverse(self):
-        ivct = InverseVaryingCelestialTransform2D(
+        ivct = InverseVaryingCelestialTransform3D(
             crpix=self.crpix,
             cdelt=self.cdelt,
             lon_pole=self.lon_pole,
@@ -478,20 +478,20 @@ class VaryingCelestialTransform3D(BaseVaryingCelestialTransform3D):
 
 # TODO: Test
 class InverseVaryingCelestialTransform3D(BaseVaryingCelestialTransform3D):
-    n_inputs = 4
+    n_inputs = 5
     n_outputs = 2
 
     @property
     def input_units(self):
-        return {"lon": u.deg, "lat": u.deg, "z": u.pix, "q": u.pix}
+        return {"lon": u.deg, "lat": u.deg, "m": u.pix, "z": u.pix, "q": u.pix}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.inputs = ("lon", "lat", "z", "q")
+        self.inputs = ("lon", "lat", "m", "z", "q")
         self.outputs = ("x", "y")
 
-    def evaluate(self, lon, lat, z, q, crpix, cdelt, lon_pole, **kwargs):
-        return self._map_transform(lon, lat, z, q, crpix, cdelt, lon_pole,
+    def evaluate(self, lon, lat, m, z, q, crpix, cdelt, lon_pole, **kwargs):
+        return self._map_transform(lon, lat, m, z, q, crpix, cdelt, lon_pole,
                                    inverse=True)
 
 
@@ -760,21 +760,21 @@ class VaryingCelestialTransformSlit3D(BaseVaryingCelestialTransform):
         return x_out, y_out
 
 # TODO: Test
-class InverseVaryingCelestialTransformSlit3D(BaseVaryingCelestialTransform2D):
-    n_inputs = 4
+class InverseVaryingCelestialTransformSlit3D(BaseVaryingCelestialTransform3D):
+    n_inputs = 5
     n_outputs = 1
 
     @property
     def input_units(self):
-        return {"lon": u.deg, "lat": u.deg, "raster": u.pix, "repeat": u.pix}
+        return {"lon": u.deg, "lat": u.deg, "meas_num": u.pix, "raster": u.pix, "repeat": u.pix}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.inputs = ("lon", "lat", "raster", "repeat")
+        self.inputs = ("lon", "lat", "meas_num", "raster", "repeat")
         self.outputs = ("slit-y",)
 
-    def evaluate(self, lon, lat, raster, repeat, crpix, cdelt, lon_pole, **kwargs):
-        return self._map_transform(lon, lat, raster, repeat, crpix, cdelt,
+    def evaluate(self, lon, lat, meas_num, raster, repeat, crpix, cdelt, lon_pole, **kwargs):
+        return self._map_transform(lon, lat, meas_num, raster, repeat, crpix, cdelt,
                                    lon_pole, inverse=True)[0]
 
 class CoupledCompoundModel(CompoundModel):

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -16,26 +16,34 @@ __all__ = [
     'CoupledCompoundModel',
     'InverseVaryingCelestialTransform',
     'InverseVaryingCelestialTransform2D',
+    'InverseVaryingCelestialTransform3D',
     'InverseVaryingCelestialTransformSlit',
     'InverseVaryingCelestialTransformSlit2D',
+    'InverseVaryingCelestialTransformSlit3D',
     'VaryingCelestialTransform',
     'VaryingCelestialTransform2D',
+    'VaryingCelestialTransform3D',
     'VaryingCelestialTransformSlit',
     'VaryingCelestialTransformSlit2D',
+    'VaryingCelestialTransformSlit3D',
     'BaseVaryingCelestialTransform',
     'BaseVaryingCelestialTransform2D',
     'BaseVaryingCelestialTransformSlit',
+    "generate_celestial_transform",
+    "varying_celestial_transform_from_tables",
     'Ravel',
     'Unravel',
 ]
 
 
-def generate_celestial_transform(crpix: Union[Iterable[float], u.Quantity],
-                                 cdelt: Union[Iterable[float], u.Quantity],
-                                 pc: Union[ArrayLike, u.Quantity],
-                                 crval: Union[Iterable[float], u.Quantity],
-                                 lon_pole: Union[float, u.Quantity] = None,
-                                 projection: Model = m.Pix2Sky_TAN()) -> CompoundModel:
+def generate_celestial_transform(
+        crpix: Union[Iterable[float], u.Quantity],
+        cdelt: Union[Iterable[float], u.Quantity],
+        pc: Union[ArrayLike, u.Quantity],
+        crval: Union[Iterable[float], u.Quantity],
+        lon_pole: Union[float, u.Quantity] = None,
+        projection: Model = m.Pix2Sky_TAN(),
+) -> CompoundModel:
     """
     Create a simple celestial transform from FITS like parameters.
 
@@ -143,11 +151,11 @@ class BaseVaryingCelestialTransform(Model, ABC):
 
     def __init__(self, *args, crval_table=None, pc_table=None, projection=m.Pix2Sky_TAN(), **kwargs):
         super().__init__(*args, **kwargs)
-
-        (self.table_shape,
-         self.pc_table,
-         self.crval_table) = self._validate_table_shapes(np.asanyarray(pc_table),
-                                                         np.asanyarray(crval_table))
+        (
+            self.table_shape,
+            self.pc_table,
+            self.crval_table
+        ) = self._validate_table_shapes(np.asanyarray(pc_table), np.asanyarray(crval_table))
 
         if not isinstance(projection, m.Pix2SkyProjection):
             raise TypeError("The projection keyword should be a Pix2SkyProjection model class.")
@@ -182,12 +190,14 @@ class BaseVaryingCelestialTransform(Model, ABC):
         if (np.array(ind) > np.array(self.table_shape) - 1).any() or (np.array(ind) < 0).any():
             return m.Const1D(fill_val) & m.Const1D(fill_val)
 
-        sct = generate_celestial_transform(crpix=crpix,
-                                           cdelt=cdelt,
-                                           pc=self.pc_table[ind],
-                                           crval=self.crval_table[ind],
-                                           lon_pole=lon_pole,
-                                           projection=self.projection)
+        sct = generate_celestial_transform(
+            crpix=crpix,
+            cdelt=cdelt,
+            pc=self.pc_table[ind],
+            crval=self.crval_table[ind],
+            lon_pole=lon_pole,
+            projection=self.projection,
+        )
 
         return sct
 
@@ -254,6 +264,7 @@ class VaryingCelestialTransform(BaseVaryingCelestialTransform):
 
     @property
     def input_units(self):
+        # NB: x and y are normally on the detector and z is typically the number of raster steps
         return {"x": u.pix, "y": u.pix, "z": u.pix}
 
     def evaluate(self, x, y, z, crpix, cdelt, lon_pole):
@@ -261,12 +272,14 @@ class VaryingCelestialTransform(BaseVaryingCelestialTransform):
 
     @property
     def inverse(self):
-        ivct = InverseVaryingCelestialTransform(crpix=self.crpix,
-                                                cdelt=self.cdelt,
-                                                lon_pole=self.lon_pole,
-                                                pc_table=self.pc_table,
-                                                crval_table=self.crval_table,
-                                                projection=self.projection)
+        ivct = InverseVaryingCelestialTransform(
+            crpix=self.crpix,
+            cdelt=self.cdelt,
+            lon_pole=self.lon_pole,
+            pc_table=self.pc_table,
+            crval_table=self.crval_table,
+            projection=self.projection,
+        )
         return ivct
 
 
@@ -356,12 +369,14 @@ class VaryingCelestialTransform2D(BaseVaryingCelestialTransform2D):
 
     @property
     def inverse(self):
-        ivct = InverseVaryingCelestialTransform2D(crpix=self.crpix,
-                                                  cdelt=self.cdelt,
-                                                  lon_pole=self.lon_pole,
-                                                  pc_table=self.pc_table,
-                                                  crval_table=self.crval_table,
-                                                  projection=self.projection)
+        ivct = InverseVaryingCelestialTransform2D(
+            crpix=self.crpix,
+            cdelt=self.cdelt,
+            lon_pole=self.lon_pole,
+            pc_table=self.pc_table,
+            crval_table=self.crval_table,
+            projection=self.projection,
+        )
         return ivct
 
 
@@ -382,8 +397,105 @@ class InverseVaryingCelestialTransform2D(BaseVaryingCelestialTransform2D):
         return self._map_transform(lon, lat, z, q, crpix, cdelt, lon_pole,
                                    inverse=True)
 
+class BaseVaryingCelestialTransform3D(BaseVaryingCelestialTransform, ABC):
+    def _map_transform(self, x, y, m, z, q, crpix, cdelt, lon_pole, inverse=False):
+        # We need to broadcast the arrays together so they are all the same shape
+        bx, by, bm, bz, bq = np.broadcast_arrays(x, y, m, z, q, subok=True)
+        # Convert the z coordinate into an index to the lookup tables
+        zind = self.sanitize_index(bz)
+        qind = self.sanitize_index(bq)
+        mind = self.sanitize_index(bm)
 
-class BaseVaryingCelestialTransformSlit(BaseVaryingCelestialTransform):
+        # Generate output arrays (ignore units for simplicity)
+        if isinstance(bx, u.Quantity):
+            x_out = np.empty_like(bx.value)
+            y_out = np.empty_like(by.value)
+        else:
+            x_out = np.empty_like(bx)
+            y_out = np.empty_like(by)
+
+        # We now loop over every unique value of z and compute the transform.
+        # This means we make the minimum number of calls possible to the transform.
+        for mm in np.unique(mind):
+            for qq in np.unique(qind):
+                for zz in np.unique(zind):
+                    # Scalar parameters are reshaped to be length one arrays by modeling
+                    sct = self.transform_at_index((mm, zz, qq), crpix[0], cdelt[0], lon_pole[0])
+
+                    # Call this transform for all values of x, y where z == zind q == qind and m == mind
+                    mask = np.logical_and(mind == mm, zind == zz, qind == qq)
+                    # TODO: Figure out what to do here...
+                    if inverse:
+                        xx, yy = sct.inverse(bx[mask], by[mask])
+                    else:
+                        xx, yy = sct(bx[mask], by[mask])
+
+                    if isinstance(xx, u.Quantity):
+                        x_out[mask], y_out[mask] = xx.value, yy.value
+                    else:
+                        x_out[mask], y_out[mask] = xx, yy
+
+        # Put the units back
+        if isinstance(xx, u.Quantity):
+            x_out = x_out << xx.unit
+            y_out = y_out << yy.unit
+
+        return x_out, y_out
+
+
+
+class VaryingCelestialTransform3D(BaseVaryingCelestialTransform3D):
+    n_inputs = 5
+    n_outputs = 2
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.inputs = ("x", "y", "m", "z", "q")
+        self.outputs = ("lon", "lat")
+
+        if len(self.table_shape) != 3:
+            raise ValueError("This model can only be constructed with a three dimensional lookup table.")
+
+    @property
+    def input_units(self):
+        return {"x": u.pix, "y": u.pix, "m": u.pix, "z": u.pix, "q": u.pix}
+
+    def evaluate(self, x, y, m, z, q, crpix, cdelt, lon_pole):
+        return self._map_transform(x, y, m, z, q, crpix, cdelt, lon_pole)
+
+    @property
+    def inverse(self):
+        ivct = InverseVaryingCelestialTransform2D(
+            crpix=self.crpix,
+            cdelt=self.cdelt,
+            lon_pole=self.lon_pole,
+            pc_table=self.pc_table,
+            crval_table=self.crval_table,
+            projection=self.projection,
+        )
+        return ivct
+
+
+# TODO: Test
+class InverseVaryingCelestialTransform3D(BaseVaryingCelestialTransform3D):
+    n_inputs = 4
+    n_outputs = 2
+
+    @property
+    def input_units(self):
+        return {"lon": u.deg, "lat": u.deg, "z": u.pix, "q": u.pix}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.inputs = ("lon", "lat", "z", "q")
+        self.outputs = ("x", "y")
+
+    def evaluate(self, lon, lat, z, q, crpix, cdelt, lon_pole, **kwargs):
+        return self._map_transform(lon, lat, z, q, crpix, cdelt, lon_pole,
+                                   inverse=True)
+
+
+class BaseVaryingCelestialTransformSlit(BaseVaryingCelestialTransform, ABC):
     def _map_transform(self, x, y, crpix, cdelt, lon_pole, inverse=False):
         # We need to broadcast the arrays together so they are all the same shape
         bx, by = np.broadcast_arrays(x, y, subok=True)
@@ -447,12 +559,14 @@ class VaryingCelestialTransformSlit(BaseVaryingCelestialTransformSlit):
 
     @property
     def inverse(self):
-        ivct = InverseVaryingCelestialTransformSlit(crpix=self.crpix,
-                                                    cdelt=self.cdelt,
-                                                    lon_pole=self.lon_pole,
-                                                    pc_table=self.pc_table,
-                                                    crval_table=self.crval_table,
-                                                    projection=self.projection)
+        ivct = InverseVaryingCelestialTransformSlit(
+            crpix=self.crpix,
+            cdelt=self.cdelt,
+            lon_pole=self.lon_pole,
+            pc_table=self.pc_table,
+            crval_table=self.crval_table,
+            projection=self.projection,
+        )
         return ivct
 
 
@@ -495,12 +609,14 @@ class VaryingCelestialTransformSlit2D(BaseVaryingCelestialTransform):
 
     @property
     def inverse(self):
-        ivct = InverseVaryingCelestialTransformSlit2D(crpix=self.crpix,
-                                                      cdelt=self.cdelt,
-                                                      lon_pole=self.lon_pole,
-                                                      pc_table=self.pc_table,
-                                                      crval_table=self.crval_table,
-                                                      projection=self.projection)
+        ivct = InverseVaryingCelestialTransformSlit2D(
+            crpix=self.crpix,
+            cdelt=self.cdelt,
+            lon_pole=self.lon_pole,
+            pc_table=self.pc_table,
+            crval_table=self.crval_table,
+            projection=self.projection,
+        )
         return ivct
 
     def _map_transform(self, x, y, z, crpix, cdelt, lon_pole, inverse=False):
@@ -528,7 +644,7 @@ class VaryingCelestialTransformSlit2D(BaseVaryingCelestialTransform):
                 # Call this transform for all values of x, y where z == zind
                 mask = np.logical_and(zind == zzind, yind == yyind)
                 if inverse:
-                    # Note this isn't use as the inverse of this model uses the
+                    # Note this isn't used as the inverse of this model uses the
                     # standard 2D inverse.
                     xx, yy = sct.inverse(bx[mask], by[mask])  # pragma: no cover
                 else:
@@ -564,6 +680,102 @@ class InverseVaryingCelestialTransformSlit2D(BaseVaryingCelestialTransform2D):
         return self._map_transform(lon, lat, raster, repeat, crpix, cdelt,
                                    lon_pole, inverse=True)[0]
 
+class VaryingCelestialTransformSlit3D(BaseVaryingCelestialTransform):
+    n_inputs = 4
+    n_outputs = 2
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.inputs = ("along_slit", "meas_num", "raster", "repeat")
+        self.outputs = ("lon", "lat")
+
+        # TODO: Will this work for 2D if num_meas == 1?
+        if len(self.table_shape) != 3:
+            raise ValueError("This model can only be constructed with a three dimensional lookup table.")
+
+    @property
+    def input_units(self):
+        return {"along_slit": u.pix, "meas_num": u.pix, "raster": u.pix, "repeat": u.pix}
+
+    def evaluate(self, along_slit, meas_num, raster, repeat, crpix, cdelt, lon_pole):
+        return self._map_transform(along_slit, meas_num, raster, repeat, crpix, cdelt, lon_pole)
+
+    @property
+    def inverse(self):
+        ivct = InverseVaryingCelestialTransformSlit3D(
+            crpix=self.crpix,
+            cdelt=self.cdelt,
+            lon_pole=self.lon_pole,
+            pc_table=self.pc_table,
+            crval_table=self.crval_table,
+            projection=self.projection,
+        )
+        return ivct
+
+    def _map_transform(self, x, m, y, z, crpix, cdelt, lon_pole, inverse=False):
+        # We need to broadcast the arrays together so they are all the same shape
+        bx, bm, by, bz = np.broadcast_arrays(x, m, y, z, subok=True)
+        # Convert the z coordinate into an index to the lookup tables
+        zind = self.sanitize_index(bz)
+        yind = self.sanitize_index(by)
+        mind = self.sanitize_index(bm)
+
+        # Generate output arrays (ignore units for simplicity)
+        if isinstance(bx, u.Quantity):
+            x_out = np.empty_like(bx.value)
+            y_out = np.empty_like(by.value)
+        else:
+            x_out = np.empty_like(bx)
+            y_out = np.empty_like(by)
+
+        # We now loop over every unique value of y and z and compute the transform.
+        # This means we make the minimum number of calls possible to the transform.
+        # TODO: why this particular order?
+        for mmind in np.unique(mind):
+            for yyind in np.unique(yind):
+                for zzind in np.unique(zind):
+                    # Scalar parameters are reshaped to be length one arrays by modeling
+                    sct = self.transform_at_index((mmind, zzind, yyind), crpix[0], cdelt[0], lon_pole[0])
+
+                    # Call this transform for all values of x, y where m == mind, y == yind and z == zind
+                    mask = np.logical_and(mmind == mind, zind == zzind, yind == yyind)
+                    if inverse:
+                        # TODO: figure out what to do here...
+                        # Note this isn't use as the inverse of this model uses the
+                        # standard 2D inverse.
+                        xx, yy = sct.inverse(bx[mask], by[mask])  # pragma: no cover
+                    else:
+                        xx, yy = sct(bx[mask], by[mask])
+
+                    if isinstance(xx, u.Quantity):
+                        x_out[mask], y_out[mask] = xx.value, yy.value
+                    else:
+                        x_out[mask], y_out[mask] = xx, yy
+
+        # Put the units back
+        if isinstance(xx, u.Quantity):
+            x_out = x_out << xx.unit
+            y_out = y_out << yy.unit
+
+        return x_out, y_out
+
+# TODO: Test
+class InverseVaryingCelestialTransformSlit3D(BaseVaryingCelestialTransform2D):
+    n_inputs = 4
+    n_outputs = 1
+
+    @property
+    def input_units(self):
+        return {"lon": u.deg, "lat": u.deg, "raster": u.pix, "repeat": u.pix}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.inputs = ("lon", "lat", "raster", "repeat")
+        self.outputs = ("slit-y",)
+
+    def evaluate(self, lon, lat, raster, repeat, crpix, cdelt, lon_pole, **kwargs):
+        return self._map_transform(lon, lat, raster, repeat, crpix, cdelt,
+                                   lon_pole, inverse=True)[0]
 
 class CoupledCompoundModel(CompoundModel):
     """
@@ -705,57 +917,51 @@ class CoupledCompoundModel(CompoundModel):
 
         return matrix
 
+varying_celestial_transform_dict = {
+    # Map (slit, num_dims, inverse) to class
+    (False, 1, False): VaryingCelestialTransform,
+    (False, 2, False): VaryingCelestialTransform2D,
+    (False, 3, False): VaryingCelestialTransform3D,
+    (True,  1, False): VaryingCelestialTransformSlit,
+    (True,  2, False): VaryingCelestialTransformSlit2D,
+    (True,  3, False): VaryingCelestialTransformSlit3D,
+    (False, 1,  True): InverseVaryingCelestialTransform,
+    (False, 2,  True): InverseVaryingCelestialTransform2D,
+    (False, 3,  True): InverseVaryingCelestialTransform3D,
+    (True,  1,  True): InverseVaryingCelestialTransformSlit,
+    (True,  2,  True): InverseVaryingCelestialTransformSlit2D,
+    (True,  3,  True): InverseVaryingCelestialTransformSlit3D,
+}
 
-def varying_celestial_transform_from_tables(crpix: Union[Iterable[float], u.Quantity],
-                                            cdelt: Union[Iterable[float], u.Quantity],
-                                            pc_table: Union[ArrayLike, u.Quantity],
-                                            crval_table: Union[Iterable[float], u.Quantity],
-                                            lon_pole: Union[float, u.Quantity] = None,
-                                            projection: Model = m.Pix2Sky_TAN(),
-                                            inverse=False,
-                                            slit=False,
-                                            ) -> BaseVaryingCelestialTransform:
+def varying_celestial_transform_from_tables(
+        crpix: Union[Iterable[float], u.Quantity],
+        cdelt: Union[Iterable[float], u.Quantity],
+        pc_table: Union[ArrayLike, u.Quantity],
+        crval_table: Union[Iterable[float], u.Quantity],
+        lon_pole: Union[float, u.Quantity] = None,
+        projection: Model = m.Pix2Sky_TAN(),
+        inverse=False,
+        slit=False,
+) -> BaseVaryingCelestialTransform:
     """
     Generate a `.BaseVaryingCelestialTransform` based on the dimensionality of the tables.
     """
 
-    table_shape, _, _ = BaseVaryingCelestialTransform._validate_table_shapes(pc_table,
-                                                                             crval_table)
-
-    if (table_d := len(table_shape)) not in (1, 2):
+    table_shape, _, _ = BaseVaryingCelestialTransform._validate_table_shapes(
+        pc_table,
+        crval_table,
+    )
+    if (table_d := len(table_shape)) not in range(1, 4):
         raise ValueError("Only one or two dimensional lookup tables are supported.")
 
-    # TODO: Looks like a candidate for single dispatch
-    if inverse:
-        if slit:
-            if table_d == 1:
-                cls = InverseVaryingCelestialTransformSlit
-            elif table_d == 2:
-                cls = InverseVaryingCelestialTransformSlit2D
-        else:
-            if table_d == 1:
-                cls = InverseVaryingCelestialTransform
-            elif table_d == 2:
-                cls = InverseVaryingCelestialTransform2D
-    else:
-        if slit:
-            if table_d == 1:
-                cls = VaryingCelestialTransformSlit
-            elif table_d == 2:
-                cls = VaryingCelestialTransformSlit2D
-        else:
-            if table_d == 1:
-                cls = VaryingCelestialTransform
-            elif table_d == 2:
-                cls = VaryingCelestialTransform2D
-
+    cls = varying_celestial_transform_dict[(slit, table_d, inverse)]
     return cls(
         crpix=crpix,
         cdelt=cdelt,
         crval_table=crval_table,
         pc_table=pc_table,
         lon_pole=lon_pole,
-        projection=projection
+        projection=projection,
     )
 
 

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -9,9 +9,9 @@ from astropy.modeling import CompoundModel
 from astropy.modeling.models import Tabular1D
 
 from dkist.wcs.models import VaryingCelestialTransform2D  # VaryingCelestialTransform3D,
-from dkist.wcs.models import (Ravel, Unravel,  # VaryingCelestialTransformSlit3D,
-                              VaryingCelestialTransform, VaryingCelestialTransformSlit,
-                              VaryingCelestialTransformSlit2D, generate_celestial_transform,
+from dkist.wcs.models import (Ravel, Unravel, VaryingCelestialTransform,
+                              VaryingCelestialTransformSlit, VaryingCelestialTransformSlit2D,
+                              VaryingCelestialTransformSlit3D, generate_celestial_transform,
                               varying_celestial_transform_from_tables)
 
 
@@ -290,7 +290,7 @@ def test_vct_dispatch():
                                                      **kwargs)
 
     assert isinstance(vct_2d, VaryingCelestialTransform2D)
-
+    # TODO: Update for new 3D capability
     with pytest.raises(ValueError, match="Only one or two dimensional lookup tables are supported"):
         varying_celestial_transform_from_tables(pc_table=varying_matrix_lt[1:].reshape((3, 2, 2, 2, 2)),
                                                 crval_table=crval_table[1:].reshape((3, 2, 2, 2)),
@@ -355,7 +355,7 @@ def test_vct_slit2d():
     assert u.allclose(ipixel, pixel[0], atol=1e-5*u.pix)
 
 def test_vct_slit3d():
-    pc_table = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.arcsec
+    pc_table = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 30)] * u.arcsec
     pc_table = pc_table.reshape((5, 2, 3, 2, 2))
 
     kwargs = dict(crpix=(5, 5) * u.pix,
@@ -366,7 +366,7 @@ def test_vct_slit3d():
     vct_slit = VaryingCelestialTransformSlit3D(pc_table=pc_table, **kwargs)
     pixel = (0*u.pix, 0*u.pix, 0*u.pix, 0*u.pix)
     world = vct_slit(*pixel)
-    ipixel = vct_slit.inverse(*world, 0*u.pix, 0*u.pix)
+    ipixel = vct_slit.inverse(*world, 0*u.pix, 0*u.pix, 0*u.pix)
     assert u.allclose(ipixel, pixel[0], atol=1e-5*u.pix)
 
 def test_vct_slit_unitless():

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -8,8 +8,9 @@ from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.modeling import CompoundModel
 from astropy.modeling.models import Tabular1D
 
-from dkist.wcs.models import (Ravel, Unravel, VaryingCelestialTransform,
-                              VaryingCelestialTransform2D, VaryingCelestialTransformSlit,
+from dkist.wcs.models import VaryingCelestialTransform2D  # VaryingCelestialTransform3D,
+from dkist.wcs.models import (Ravel, Unravel,  # VaryingCelestialTransformSlit3D,
+                              VaryingCelestialTransform, VaryingCelestialTransformSlit,
                               VaryingCelestialTransformSlit2D, generate_celestial_transform,
                               varying_celestial_transform_from_tables)
 
@@ -353,6 +354,20 @@ def test_vct_slit2d():
     ipixel = vct_slit.inverse(*world, 0*u.pix, 0*u.pix)
     assert u.allclose(ipixel, pixel[0], atol=1e-5*u.pix)
 
+def test_vct_slit3d():
+    pc_table = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.arcsec
+    pc_table = pc_table.reshape((5, 2, 3, 2, 2))
+
+    kwargs = dict(crpix=(5, 5) * u.pix,
+                  cdelt=(1, 1) * u.arcsec/u.pix,
+                  crval_table=(0, 0) * u.arcsec,
+                  lon_pole=180 * u.deg)
+
+    vct_slit = VaryingCelestialTransformSlit3D(pc_table=pc_table, **kwargs)
+    pixel = (0*u.pix, 0*u.pix, 0*u.pix, 0*u.pix)
+    world = vct_slit(*pixel)
+    ipixel = vct_slit.inverse(*world, 0*u.pix, 0*u.pix)
+    assert u.allclose(ipixel, pixel[0], atol=1e-5*u.pix)
 
 def test_vct_slit_unitless():
     pc_table = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 10)]

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -8,8 +8,8 @@ from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.modeling import CompoundModel
 from astropy.modeling.models import Tabular1D
 
-from dkist.wcs.models import VaryingCelestialTransform2D  # VaryingCelestialTransform3D,
 from dkist.wcs.models import (Ravel, Unravel, VaryingCelestialTransform,
+                              VaryingCelestialTransform2D, VaryingCelestialTransform3D,
                               VaryingCelestialTransformSlit, VaryingCelestialTransformSlit2D,
                               VaryingCelestialTransformSlit3D, generate_celestial_transform,
                               varying_celestial_transform_from_tables)
@@ -269,32 +269,41 @@ def test_varying_transform_4d_pc_shapes(pixel, lon_shape):
 
 
 def test_vct_dispatch():
-    varying_matrix_lt = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.arcsec
-    varying_matrix_lt = varying_matrix_lt.reshape((5, 3, 2, 2))
-
-    crval_table = list(zip(np.arange(1, 16), np.arange(16, 31))) * u.arcsec
-    crval_table = crval_table.reshape((5, 3, 2))
-
+    varying_matrix_lt = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 16)] * u.arcsec
+    varying_matrix_lt = varying_matrix_lt.reshape((2, 2, 2, 2, 2, 2))
+    crval_table = list(zip(np.arange(1, 17), np.arange(17, 33))) * u.arcsec
+    crval_table = crval_table.reshape((2, 2, 2, 2, 2))
     kwargs = dict(crpix=(5, 5) * u.pix,
                   cdelt=(1, 1) * u.arcsec/u.pix,
                   lon_pole=180 * u.deg)
 
-    vct_3d = varying_celestial_transform_from_tables(pc_table=varying_matrix_lt[0],
-                                                     crval_table=crval_table[0],
-                                                     **kwargs)
+    vct = varying_celestial_transform_from_tables(
+        pc_table=varying_matrix_lt[0, 0, 0],
+        crval_table=crval_table[0, 0, 0],
+        **kwargs,
+    )
+    assert isinstance(vct, VaryingCelestialTransform)
 
-    assert isinstance(vct_3d, VaryingCelestialTransform)
-
-    vct_2d = varying_celestial_transform_from_tables(pc_table=varying_matrix_lt,
-                                                     crval_table=crval_table,
-                                                     **kwargs)
-
+    vct_2d = varying_celestial_transform_from_tables(
+        pc_table=varying_matrix_lt[0, 0],
+        crval_table=crval_table[0, 0],
+        **kwargs,
+    )
     assert isinstance(vct_2d, VaryingCelestialTransform2D)
-    # TODO: Update for new 3D capability
-    with pytest.raises(ValueError, match="Only one or two dimensional lookup tables are supported"):
-        varying_celestial_transform_from_tables(pc_table=varying_matrix_lt[1:].reshape((3, 2, 2, 2, 2)),
-                                                crval_table=crval_table[1:].reshape((3, 2, 2, 2)),
-                                                **kwargs)
+
+    vct_3d = varying_celestial_transform_from_tables(
+        pc_table=varying_matrix_lt[0],
+        crval_table=crval_table[0],
+        **kwargs
+    )
+    assert isinstance(vct_3d, VaryingCelestialTransform3D)
+
+    with pytest.raises(ValueError, match="Only 1D, 2D and 3D lookup tables are supported."):
+        varying_celestial_transform_from_tables(
+            pc_table=varying_matrix_lt,
+            crval_table=crval_table,
+            **kwargs,
+        )
 
 
 def test_vct_shape_errors():


### PR DESCRIPTION
Adds 3D capability to VaryingCelestialTransform and VaryingCelestialTransformSlit. Submitting PR now to facilitate deployment of Cryonirsp pipeline on DKIST DC stacks. A later upgrade to this code will include additional unit tests for transforms to include round trip pixel-to-world --> world to pixel testing. In addition, I will consolidate the many different VaryingCelestialTransform classes into far fewer, and evaluate the possibility of generic N dimensional VaryingCelestialTransform  and VaryingCelestialTransformSlit classes.