### PR TITLE
move iers pre-fetch to conftest.py from tox.ini

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,10 @@
 import matplotlib
+import pytest
 
 matplotlib.use("Agg")
+
+
+def pytest_configure(config):
+    # pre-cache the IERS file for astropy to prevent downloads
+    # which will cause errors with remote_data off
+    from astropy.utils.iers import IERS_Auto; IERS_Auto.open()

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,6 @@ setenv =
 extras = tests
 commands =
     pip freeze --all --no-input
-    # pre-cache the IERS file for astropy to prevent downloads with remote_data off
-    python -c 'from astropy.utils.iers import IERS_Auto; IERS_Auto.open()'
     {env:PYTEST_COMMAND} {posargs}
 description =
     run tests


### PR DESCRIPTION
asdf includes dkist in it's downstream testing and has noticed recent failures during test collection due to remote data access during tests.
https://github.com/asdf-format/asdf/actions/runs/5716903417/job/15489509194?pr=1597#step:10:684

While looking into the issue I noticed the recent addition tox.ini:
https://github.com/DKISTDC/dkist/blob/25af24a17455aa4094ecb031f4d138cb2732ba5c/tox.ini#L18-L19

As an alternative, this PR moves the fetch to `pytest_configure` in [conftest.py](https://github.com/DKISTDC/dkist/blob/25af24a17455aa4094ecb031f4d138cb2732ba5c/conftest.py) to allow this pre-fetch to occur during both:
- downstream testing in other packages which don't use the tox.ini of this package (for example asdf)
- local runs that occur outside of tox (I was able to replicate the error above locally by calling `astropy.utils.data.clear_download_cache` prior to the test run).