### PR TITLE
import ValidationError from asdf, drop jsonschema as a dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,3 @@
-1.0.1 (unreleased)
-==================
-
-Trivial/Internal Changes
-------------------------
-
-- Import `ValidationError` from `asdf.exceptions` and drop `jsonschema` as a dependency. (`#295 <https://github.com/DKISTDC/dkist/pull/295>`_)
-
 1.0.0 (2023-08-09)
 ==================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+1.0.1 (unreleased)
+==================
+
+Trivial/Internal Changes
+------------------------
+
+- Import `ValidationError` from `asdf.exceptions` and drop `jsonschema` as a dependency. (`#295 <https://github.com/DKISTDC/dkist/pull/295>`_)
+
 1.0.0 (2023-08-09)
 ==================
 

--- a/changelog/295.bugfix.rst
+++ b/changelog/295.bugfix.rst
@@ -1,0 +1,1 @@
+Import ValidationError from asdf, drop jsonschema as a dependency.

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -2,10 +2,10 @@ import importlib.resources as importlib_resources
 from pathlib import Path
 from functools import singledispatch
 
-from asdf.exceptions import ValidationError
 from parfive import Results
 
 import asdf
+from asdf.exceptions import ValidationError
 
 
 @singledispatch

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -2,7 +2,7 @@ import importlib.resources as importlib_resources
 from pathlib import Path
 from functools import singledispatch
 
-from jsonschema.exceptions import ValidationError
+from asdf.exceptions import ValidationError
 from parfive import Results
 
 import asdf

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -7,8 +7,10 @@ from parfive import Results
 import asdf
 
 try:
+    # first try to import from asdf.exceptions for asdf 2.15+
     from asdf.exceptions import ValidationError
 except ImportError:
+    # fall back to top level asdf for older versions of asdf
     from asdf import ValidationError
 
 

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -5,6 +5,7 @@ from functools import singledispatch
 from parfive import Results
 
 import asdf
+
 try:
     from asdf.exceptions import ValidationError
 except ImportError:

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -5,7 +5,10 @@ from functools import singledispatch
 from parfive import Results
 
 import asdf
-from asdf.exceptions import ValidationError
+try:
+    from asdf.exceptions import ValidationError
+except ImportError:
+    from asdf import ValidationError
 
 
 @singledispatch

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,9 @@ packages = find:
 include_package_data = True
 install_requires =
   appdirs>=1.4
-  asdf>=2.15.1
+  asdf>=2.9.2
   asdf-astropy>=0.1.1
-  asdf-transform-schemas>=0.3
+  asdf-transform-schemas
   astropy>=5
   dask[array]>=2021.8.0
   globus-sdk>=3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find:
 include_package_data = True
 install_requires =
   appdirs>=1.4
-  asdf>=2.9.2
+  asdf>=2.15.1
   asdf-astropy>=0.1.1
   asdf-transform-schemas
   astropy>=5
@@ -35,7 +35,6 @@ install_requires =
   parfive[ftp]>=1.5
   sunpy[net,asdf]>=4.0.7
   setuptools>=59
-  jsonschema>=3.2
   aiohttp>=3.6
   tqdm>=4.63
 setup_requires = setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
   appdirs>=1.4
   asdf>=2.15.1
   asdf-astropy>=0.1.1
-  asdf-transform-schemas
+  asdf-transform-schemas>=0.3
   astropy>=5
   dask[array]>=2021.8.0
   globus-sdk>=3.0


### PR DESCRIPTION
asdf has recently run into compatibility issues with jsonschema 4.18+. The newer versions of jsonschema dropped support for a feature required in asdf which left us with little choice but to vendorize jsonschema. This presented an opportunity to clean up some leaky bits of the asdf API including the issue that `jsonschema.ValidationError` was transparently passed to user code and libraries (like dkist) had to import `ValidationError` from jsonschema.

asdf 2.15 introduced `ValidationError` as part of the public api available at `asdf.exceptions.ValidationError`. This PR changes the import `ValidationError` from `asdf.exceptions` (instead of jsonschema).

asdf 2.15.1 includes the vendorized jsonschema, keeps jsonschema as a dependency and attempts to use the exceptions from the installed jsonschema (to not break some downstream libraries that use asdf). We are planning to drop jsonschema as a dependency and stop using it's exceptions in asdf 3.0 (or possibly in 2.15.2 if further changes to jsonschema make it's exceptions incompatible).

Please see the [What's New](https://asdf.readthedocs.io/en/latest/asdf/whats_new.html#jsonschema) page in the asdf 2.15.1 docs for more information and let me know if you have any questions, comments or concerns.