### PR TITLE
implement select_tag for dataset converter

### DIFF
--- a/changelog/297.bugfix.rst
+++ b/changelog/297.bugfix.rst
@@ -1,0 +1,1 @@
+Implement missing ``select_tag`` method of ``DatasetConverter``.

--- a/dkist/io/asdf/converters/dataset.py
+++ b/dkist/io/asdf/converters/dataset.py
@@ -11,6 +11,13 @@ class DatasetConverter(Converter):
     ]
     types = ["dkist.dataset.dataset.Dataset"]
 
+    def select_tag(self, obj, tags, ctx):
+        # asdf sorts the tags supported by the current extension
+        # in the case that multiple tags are relevant, pick the first
+        # tag version as this most closely matches what asdf
+        # used to do prior to 3.0
+        return tags[0]
+
     def from_yaml_tree(self, node, tag, ctx):
         from dkist.dataset import Dataset
 


### PR DESCRIPTION
This PR adds a `select_tag` method to `DatasetConverter`. This addition is intended to provide compatibility with the soon to be released asdf 3.0 (more on that below).

The code added in `select_tag` matches what is provided by the parent class's method [Converter.select_tag](https://github.com/asdf-format/asdf/blob/53b87b4d628305db4e46eec21c63d2ada047afd3/asdf/extension/_converter.py#L85) in asdf 2.15.1. The need to add this seemingly redundant method is a bit complicated but I will hopefully explain the context below.

`select_tag` allows the converter to select between one or more tags that are supported by the extension that is using the converter (see the asdf docs for [more details](https://asdf.readthedocs.io/en/latest/asdf/extending/converters.html#multiple-tags)). dkist currently lists 3 supported tags in the 0.9.0 manifest:
https://github.com/DKISTDC/dkist/blob/c7e61155a2ac73d6c0bd0b389c5aea263b17076e/dkist/io/asdf/resources/manifests/dkist-0.9.0.yaml#L11-L16
Yet the `DatasetConverter` does not implement `select_tag` and instead inherits `select_tag` from the parent `Converter` class. This causes the converter to always select the smallest tag version (see this issue for more context: https://github.com/asdf-format/asdf/issues/1086). This asdf PR (which is planned for 3.0: https://github.com/asdf-format/asdf/pull/1594) removes `select_tag` from the `Converter` parent class and will start issuing a warning for a converter that inherits from `Converter`, supports multiple tags, and does not implement `select_tag` (conditions that match `DatasetConverter` without the changes in this PR).

A few alternatives to the changes in this PR that should also address the issue are:
- If possible, archive and stop using the 0.9.0 manifest
- Implement a `select_tag` method for `DatasetConverter` with different logic for selecting a tag (perhaps the newest version?). This would likely lead to changes in the files written using the 0.9.0 extension

Please let me know if more information and changes would be helpful.