### PR TITLE
convert varying_celestial_tranform schema ref to uri instead of tag

### DIFF
--- a/changelog/298.bugfix.rst
+++ b/changelog/298.bugfix.rst
@@ -1,0 +1,1 @@
+Update varying celestial transform schema ref to use a uri instead of a tag.

--- a/dkist/io/asdf/resources/schemas/varying_celestial_transform-1.0.0.yaml
+++ b/dkist/io/asdf/resources/schemas/varying_celestial_transform-1.0.0.yaml
@@ -30,7 +30,7 @@ properties:
       - tag: "core/ndarray-1.0.0"
       - tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
   projection:
-    $ref: "tag:stsci.edu:asdf/transform/transform-1.2.0"
+    $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
 
 required: [crpix, cdelt, lon_pole, crval_table, pc_table, projection]
 additionalProperties: true


### PR DESCRIPTION
asdf 3.0 will begin issuing a warning when a non-uri tag is encountered in a schema `$ref`. One such tag exists in the varying celestial transform schema:
https://github.com/DKISTDC/dkist/blob/main/dkist/io/asdf/resources/schemas/varying_celestial_transform-1.0.0.yaml#L33

This PR updates the schema replacing the tag with the corresponding and equivalent uri (`http://stsci.edu/schemas/asdf/transform/transform-1.2.0`). The uri used to replace the tag is identical to the uri that is resolved by the tag and should have no impact on the schema or code that uses the schema (aside from preventing the warning when asdf 3.0 is released).