### PR TITLE
add asdf-astropy to devdeps, update schemas to use tag wildcards, add warning ignore for gwcs 0.18.3

### DIFF
--- a/changelog/308.trivial.rst
+++ b/changelog/308.trivial.rst
@@ -1,0 +1,3 @@
+To improve compatibility with external libraries that provide ASDF serialization and
+validation (like asdf-astropy) dkist schemas were updated to use tag wildcards
+when checking tagged objects (instead of requiring specific tag versions).

--- a/dkist/io/asdf/resources/schemas/dataset-1.0.0.yaml
+++ b/dkist/io/asdf/resources/schemas/dataset-1.0.0.yaml
@@ -15,17 +15,15 @@ properties:
 
   wcs:
     description: The coordinate system for the complete dataset.
-    anyOf:
-      - tag: "tag:stsci.edu:gwcs/wcs-1.0.0"
-      - tag: "tag:stsci.edu:gwcs/wcs-1.1.0"
+    tag: "tag:stsci.edu:gwcs/wcs-1.*"
 
   mask:
-    tag: "core/ndarray-1.0.0"
+    tag: "core/ndarray-1.*"
 
   unit:
     anyOf:
-      - tag: "unit/unit-1.0.0"
-      - tag: "tag:stsci.edu:asdf/unit/unit-1.0.0"
+      - tag: "unit/unit-1.*"
+      - tag: "tag:stsci.edu:asdf/unit/unit-1.*"
 
   meta:
     description: Dataset metadata, describing the whole dataset.
@@ -33,7 +31,7 @@ properties:
     properties:
       headers:
         description: A table of all the headers for the constituent files.
-        tag: "tag:astropy.org:astropy/table/table-1.0.0"
+        tag: "tag:astropy.org:astropy/table/table-1.*"
 
       quality:
         description: A copy of the quality report of these observations.

--- a/dkist/io/asdf/resources/schemas/dataset-1.1.0.yaml
+++ b/dkist/io/asdf/resources/schemas/dataset-1.1.0.yaml
@@ -15,15 +15,13 @@ properties:
 
   wcs:
     description: The coordinate system for the complete dataset.
-    anyOf:
-      - tag: "tag:stsci.edu:gwcs/wcs-1.0.0"
-      - tag: "tag:stsci.edu:gwcs/wcs-1.1.0"
+    tag: "tag:stsci.edu:gwcs/wcs-1.*"
 
   mask:
-    tag: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+    tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
 
   unit:
-    tag: "tag:stsci.edu:asdf/unit/unit-1.0.0"
+    tag: "tag:stsci.edu:asdf/unit/unit-1.*"
 
   meta:
     description: Dataset metadata, describing the whole dataset.
@@ -31,7 +29,7 @@ properties:
     properties:
       headers:
         description: A table of all the headers for the constituent files.
-        tag: "tag:astropy.org:astropy/table/table-1.0.0"
+        tag: "tag:astropy.org:astropy/table/table-1.*"
 
       quality:
         description: A copy of the quality report of these observations.

--- a/dkist/io/asdf/resources/schemas/varying_celestial_transform-1.0.0.yaml
+++ b/dkist/io/asdf/resources/schemas/varying_celestial_transform-1.0.0.yaml
@@ -11,24 +11,24 @@ type: object
 properties:
   crpix:
     anyOf:
-      - tag: "core/ndarray-1.0.0"
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+      - tag: "core/ndarray-1.*"
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   cdelt:
     anyOf:
-      - tag: "core/ndarray-1.0.0"
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+      - tag: "core/ndarray-1.*"
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   lon_pole:
     anyOf:
       - type: number
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   crval_table:
     anyOf:
-      - tag: "core/ndarray-1.0.0"
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+      - tag: "core/ndarray-1.*"
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   pc_table:
     anyOf:
-      - tag: "core/ndarray-1.0.0"
-      - tag: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+      - tag: "core/ndarray-1.*"
+      - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
   projection:
     $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,6 +132,8 @@ filterwarnings =
     ignore:leap-second auto-update failed due to the following exception
     ignore:"@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
     ignore:The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.
+    # Ignore warning so gwcs 0.18.3 can load
+    ignore:Converter handles multiple tags for this extension:asdf.exceptions.AsdfWarning
 
 [flake8]
 exclude = extern,sphinx,*parsetab.py,conftest.py,docs/conf.py,setup.py,__init__.py

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
     devdeps: git+https://github.com/sunpy/ndcube
     devdeps: git+https://github.com/spacetelescope/gwcs
     devdeps: git+https://github.com/asdf-format/asdf
+    devdeps: git+https://github.com/astropy/asdf-astropy
     # Autogenerate oldest dependencies from info in setup.cfg
     oldestdeps: minimum_dependencies
 


### PR DESCRIPTION
The devdeps job is failing due to testing using astropy dev (which contains some changes to where classes are implemented, specifically `CartesianRepresentation`):
https://github.com/DKISTDC/dkist/actions/runs/6509684073/job/17681742351#step:10:734
This is resulting in a `ValidationError` as asdf fails to serialize the moved `CartesianRepresentation` as the released version of asdf-astropy is not aware of the new class location.

This PR adds the development version of asdf-astropy to the devdeps job as it contains updates for compatibility with the development version of astropy including: https://github.com/astropy/asdf-astropy/pull/181

During testing it was revealed that several dkist schemas have exact tag requirements:
https://github.com/DKISTDC/dkist/blob/b95f22a5f7ea320d761e7a4834755c2077ea7c26/dkist/io/asdf/resources/schemas/dataset-1.1.0.yaml#L34
this was causing test failures as asdf-astropy dev contains a new `table-1.1.0`. This PR was updated to use wildcards for these tag validation checks (using `table-1.*` in this case).

Note that wildcards were only added to non-dkist tag references and not to dkist tags like:
https://github.com/DKISTDC/dkist/blob/b95f22a5f7ea320d761e7a4834755c2077ea7c26/dkist/io/asdf/resources/schemas/dataset-1.1.0.yaml#L14

Additionally, as the CI was failing due to a warning from gwcs 0.18.3 a warning filter was added. This should be removed when the upper pin for gwcs can be removed.