### PR TITLE
Flatten arrays in ravel evaluation

### DIFF
--- a/changelog/309.bugfix.rst
+++ b/changelog/309.bugfix.rst
@@ -1,0 +1,1 @@
+Fix broadcasting issues during pixel -> world conversion for models with a Ravel component.

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -635,6 +635,7 @@ class Ravel(Model):
         else:
             has_units = False
             input_values = inputs_
+        input_values = [item.flatten() for item in input_values]
         # round the index values, but clip them if they exceed the array bounds
         # the bounds are one less than the shape dimension value
         array_bounds = np.array(self.array_shape) - 1

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -635,7 +635,7 @@ class Ravel(Model):
         else:
             has_units = False
             input_values = inputs_
-        input_values = [item.flatten() for item in input_values]
+        input_values = [item.flatten() if isinstance(item, np.ndarray) else item for item in input_values]
         # round the index values, but clip them if they exceed the array bounds
         # the bounds are one less than the shape dimension value
         array_bounds = np.array(self.array_shape) - 1


### PR DESCRIPTION
Otherwise it breaks real hard when you try to pass multiple points into `pixel_to_world`, because of array broadcasting. This was causing `Dataset.axis_world_coords()` to have a meltdown. As far as I can tell this change fixes that behaviour without impacting anything else.