### PR TITLE
add if __main__ to changelog filter

### DIFF
--- a/.github/changelog_filter.py
+++ b/.github/changelog_filter.py
@@ -6,16 +6,17 @@ import io
 import sys
 import json
 
-input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
-source = input_stream.read()
-doc = json.loads(source)
+if __name__ == '__main__':
+    input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+    source = input_stream.read()
+    doc = json.loads(source)
 
-output_blocks = []
-for block in doc["blocks"]:
-    if output_blocks and block["t"] == "Header" and block["c"][0] == 1:
-        break
-        print(block["c"], file=sys.stderr)
-    output_blocks.append(block)
+    output_blocks = []
+    for block in doc["blocks"]:
+        if output_blocks and block["t"] == "Header" and block["c"][0] == 1:
+            break
+            print(block["c"], file=sys.stderr)
+        output_blocks.append(block)
 
-doc["blocks"] = output_blocks
-sys.stdout.write(json.dumps(doc))
+    doc["blocks"] = output_blocks
+    sys.stdout.write(json.dumps(doc))


### PR DESCRIPTION
The `changelog_filter.py` script added in https://github.com/DKISTDC/dkist/pull/329 is causing issues with test collection. This can be seen in downstream tests in asdf
https://github.com/asdf-format/asdf/actions/runs/8065305926/job/22030878789?pr=1745

and by attempting to run `pytest` in a development install of dkist:
```
>> pytest
...
___________________________________________________ ERROR collecting .github/changelog_filter.py ____________________________________________________
.github/changelog_filter.py:10: in <module>
    source = input_stream.read()
E   io.UnsupportedOperation: not readable
...
```

This PR adds an `if __name__ == '__main__'` check to the script so it does not attempt to read stdin during test collection.