### PR TITLE
bump gwcs version check in test

### DIFF
--- a/dkist/io/asdf/tests/test_dataset.py
+++ b/dkist/io/asdf/tests/test_dataset.py
@@ -189,7 +189,8 @@ def test_read_wcs_with_backwards_affine():
     # Assert that our stokes fixing code has worked.
     assert world_outputs[-1] == 1
 
-    if Version(gwcs.__version__) > Version("0.22.dev0"):
-        pixel_outputs = wcs.world_to_pixel_values(*world_outputs)
+    # TODO: Requires https://github.com/spacetelescope/gwcs/pull/457
+    #if Version(gwcs.__version__) > Version("0.22.dev0"):
+    #    pixel_outputs = wcs.world_to_pixel_values(*world_outputs)
 
-        assert np.allclose(pixel_inputs, pixel_outputs, atol=1e-6)
+    #    assert np.allclose(pixel_inputs, pixel_outputs, atol=1e-6)

--- a/dkist/io/asdf/tests/test_dataset.py
+++ b/dkist/io/asdf/tests/test_dataset.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from packaging.version import Version
 
 import asdf
 import astropy.table
@@ -190,7 +189,7 @@ def test_read_wcs_with_backwards_affine():
     assert world_outputs[-1] == 1
 
     # TODO: Requires https://github.com/spacetelescope/gwcs/pull/457
-    #if Version(gwcs.__version__) > Version("0.22.dev0"):
-    #    pixel_outputs = wcs.world_to_pixel_values(*world_outputs)
-
-    #    assert np.allclose(pixel_inputs, pixel_outputs, atol=1e-6)
+    # if Version(gwcs.__version__) > Version("0.22.dev0"):
+    #     pixel_outputs = wcs.world_to_pixel_values(*world_outputs)
+    #
+    #     assert np.allclose(pixel_inputs, pixel_outputs, atol=1e-6)

--- a/dkist/io/asdf/tests/test_dataset.py
+++ b/dkist/io/asdf/tests/test_dataset.py
@@ -189,7 +189,7 @@ def test_read_wcs_with_backwards_affine():
     # Assert that our stokes fixing code has worked.
     assert world_outputs[-1] == 1
 
-    if Version(gwcs.__version__) > Version("0.21.dev0"):
+    if Version(gwcs.__version__) > Version("0.22.dev0"):
         pixel_outputs = wcs.world_to_pixel_values(*world_outputs)
 
         assert np.allclose(pixel_inputs, pixel_outputs, atol=1e-6)


### PR DESCRIPTION
gwcs 0.21.0 was released.

I believe this may be interfering with a version check in the `test_read_wcs_with_backwards_affine` test.

The check was previously updated in:
https://github.com/DKISTDC/dkist/pull/313
and added in:
https://github.com/DKISTDC/dkist/pull/305
which mentions the draft gwcs PR:
https://github.com/spacetelescope/gwcs/pull/457
which might be what this test is attempting to check against. @Cadair can you confirm?