### PR TITLE
Remove pyargs because it currently interacts poorly with pytest-asdf

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,6 @@ envlist =
 
 [testenv]
 pypi_filter = https://raw.githubusercontent.com/sunpy/sunpy/main/.test_package_pins.txt
-# Run the tests in a temporary directory to make sure that we don't import
-# the package from the source tree
-change_dir = .tmp/{envname}
 description =
     run tests
     oldestdeps: with the oldest supported version of key dependencies
@@ -34,7 +31,7 @@ set_env =
     COLUMNS = 180
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     # Define the base test command here to allow us to add more flags for each tox factor
-    PYTEST_COMMAND = pytest -vvv -r fEs --pyargs dkist --cov-report=xml --cov=dkist --cov-config={toxinidir}/.coveragerc {toxinidir}/docs
+    PYTEST_COMMAND = pytest -vvv -r fEs --cov-report=xml --cov=dkist --cov-config={toxinidir}/.coveragerc {toxinidir}/docs
 deps =
     # For packages which publish nightly wheels this will pull the latest nightly
     devdeps: astropy>=0.0.dev0


### PR DESCRIPTION
Also @SolarDrew hates it, and we don't have compiled extensions so the best argument for it is void.