### PR TITLE
Fix Dask tokenisation performance issues by not hashing

### DIFF
--- a/changelog/361.bugfix.rst
+++ b/changelog/361.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a performance regression when dask>=2024.2.1 is installed.

--- a/dkist/io/dask_utils.py
+++ b/dkist/io/dask_utils.py
@@ -50,6 +50,6 @@ def loader_to_dask(loader_array, chunksize):
     # trying to auto calculate it by reading from the actual array on disk.
     meta = np.zeros((0,), dtype=loader_array[0].dtype)
 
-    to_array = partial(da.from_array, meta=meta, chunks=chunksize)
+    to_array = partial(da.from_array, meta=meta, chunks=chunksize, name=False)
 
     return map(to_array, loader_array)

--- a/dkist/io/dask_utils.py
+++ b/dkist/io/dask_utils.py
@@ -20,7 +20,7 @@ def stack_loader_array(loader_array, chunksize):
     -------
     array : `dask.array.Array`
     """
-    # If the chunksize sin't specified then use the whole array shape
+    # If the chunksize isn't specified then use the whole array shape
     chunksize = chunksize or loader_array.flat[0].shape
 
     if loader_array.size == 1:

--- a/dkist/io/dask_utils.py
+++ b/dkist/io/dask_utils.py
@@ -33,6 +33,11 @@ def stack_loader_array(loader_array, chunksize):
     return da.stack(stacks)
 
 
+def _partial_to_array(loader, *, meta, chunks):
+    # Set the name of the array to the filename, that should be unique within the array
+    return da.from_array(loader, meta=meta, chunks=chunks, name=loader.fileuri)
+
+
 def loader_to_dask(loader_array, chunksize):
     """
     Map a call to `dask.array.from_array` onto all the elements in ``loader_array``.
@@ -50,6 +55,6 @@ def loader_to_dask(loader_array, chunksize):
     # trying to auto calculate it by reading from the actual array on disk.
     meta = np.zeros((0,), dtype=loader_array[0].dtype)
 
-    to_array = partial(da.from_array, meta=meta, chunks=chunksize, name=False)
+    to_array = partial(_partial_to_array, meta=meta, chunks=chunksize)
 
     return map(to_array, loader_array)


### PR DESCRIPTION
It seems that due to https://github.com/dask/dask/pull/10883 which was included in dask 2024.2.1 there is now a *massive* performance overhead loading large raster ASDF files. All this time seems to be in the tokenisation step, presumably because it tries to actually compute the array or something even if the file is missing.

Based on my reading of [the docs](https://docs.dask.org/en/stable/generated/dask.array.from_array.html#dask.array.from_array) I think we can just get away with setting name to False.