### PR TITLE
More refactoring in VaryingCelestialTransform

### DIFF
--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -108,6 +108,7 @@ class BaseVaryingCelestialTransform(Model, ABC):
     standard_broadcasting = False
     _separable = False
     _input_units_allow_dimensionless = True
+    _input_units_strict = True
     _is_inverse = False
 
     crpix = Parameter()

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -274,6 +274,9 @@ class BaseVaryingCelestialTransform(Model, ABC):
         kwargs = dict(zip(keys, kwargs))
 
         # This will almost universally not be the way to put the units back but it works for the plot profiling so it'll do for now
+        if self._is_inverse:
+            return self._map_transform(*arrays, inverse=self._is_inverse, **kwargs) * u.pix
+
         return self._map_transform(*arrays, inverse=self._is_inverse, **kwargs) * u.deg
 
     @property

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -211,8 +211,8 @@ class BaseVaryingCelestialTransform(Model, ABC):
             self._transform,
             crpix=crpix,
             cdelt=cdelt,
-            pc=self.pc_table[ind].value,
-            crval=self.crval_table[ind].value,
+            pc=self.pc_table[ind],
+            crval=self.crval_table[ind],
             lon_pole=lon_pole,
             projection=self.projection,
         )
@@ -265,7 +265,6 @@ class BaseVaryingCelestialTransform(Model, ABC):
         return x_out, y_out
 
     def evaluate(self, *inputs):
-        inputs = [i.value if isinstance(i, u.Quantity) else i for i in inputs]
         # This method has to be able to take an arbitrary number of arrays but also accept not being given kwargs
         # Fortunately we know how many arrays to expect from the number of inputs
         # Anything extra is therefore a kwarg
@@ -273,12 +272,7 @@ class BaseVaryingCelestialTransform(Model, ABC):
         kwargs = inputs[self.n_inputs:]
         keys = ["crpix", "cdelt", "lon_pole"]
         kwargs = dict(zip(keys, kwargs))
-
-        # This will almost universally not be the way to put the units back but it works for the plot profiling so it'll do for now
-        if self._is_inverse:
-            return self._map_transform(*arrays, inverse=self._is_inverse, **kwargs) * u.pix
-
-        return self._map_transform(*arrays, inverse=self._is_inverse, **kwargs) * u.deg
+        return self._map_transform(*arrays, inverse=self._is_inverse, **kwargs)
 
     @property
     def input_units(self):

--- a/dkist/wcs/models.py
+++ b/dkist/wcs/models.py
@@ -210,8 +210,8 @@ class BaseVaryingCelestialTransform(Model, ABC):
             self._transform,
             crpix=crpix,
             cdelt=cdelt,
-            pc=self.pc_table[ind],
-            crval=self.crval_table[ind],
+            pc=self.pc_table[ind].value,
+            crval=self.crval_table[ind].value,
             lon_pole=lon_pole,
             projection=self.projection,
         )
@@ -264,6 +264,7 @@ class BaseVaryingCelestialTransform(Model, ABC):
         return x_out, y_out
 
     def evaluate(self, *inputs):
+        inputs = [i.value if isinstance(i, u.Quantity) else i for i in inputs]
         # This method has to be able to take an arbitrary number of arrays but also accept not being given kwargs
         # Fortunately we know how many arrays to expect from the number of inputs
         # Anything extra is therefore a kwarg
@@ -271,7 +272,9 @@ class BaseVaryingCelestialTransform(Model, ABC):
         kwargs = inputs[self.n_inputs:]
         keys = ["crpix", "cdelt", "lon_pole"]
         kwargs = dict(zip(keys, kwargs))
-        return self._map_transform(*arrays, inverse=self._is_inverse, **kwargs)
+
+        # This will almost universally not be the way to put the units back but it works for the plot profiling so it'll do for now
+        return self._map_transform(*arrays, inverse=self._is_inverse, **kwargs) * u.deg
 
     @property
     def input_units(self):

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -76,7 +76,7 @@ def test_varying_transform_no_lon_pole_unit():
     )
     trans5 = vct.transform_at_index(5)
     assert isinstance(trans5, CompoundModel)
-    assert u.allclose(trans5.right.lon_pole, 180 * u.deg)
+    assert u.allclose(trans5.right.lon_pole, 180)
 
 
 def test_varying_transform_pc():
@@ -96,7 +96,7 @@ def test_varying_transform_pc():
     # Verify that we have the 5th matrix in the series
     affine = next(filter(lambda sm: isinstance(sm, m.AffineTransformation2D), trans5.traverse_postorder()))
     assert isinstance(affine, m.AffineTransformation2D)
-    assert u.allclose(affine.matrix, varying_matrix_lt[5])
+    assert u.allclose(affine.matrix, varying_matrix_lt[5].value)
     # x.shape=(1,), y.shape=(1,), z.shape=(1,)
     pixel = (0*u.pix, 0*u.pix, 5*u.pix)
     world = vct(*pixel)
@@ -175,8 +175,8 @@ def test_varying_transform_crval():
     # Verify that we have the 2nd crval pair in the series
     crval1 = trans2.right.lon
     crval2 = trans2.right.lat
-    assert u.allclose(crval1, crval_table[2][0])
-    assert u.allclose(crval2, crval_table[2][1])
+    assert u.allclose(crval1, crval_table[2][0].to_value(u.deg))
+    assert u.allclose(crval2, crval_table[2][1].to_value(u.deg))
 
     pixel = (0*u.pix, 0*u.pix, 2*u.pix)
     world = vct(*pixel)
@@ -286,7 +286,7 @@ def test_varying_transform_4d_pc_unitless():
     ((np.arange(10) * u.pix,
       np.arange(10) * u.pix,
       np.arange(5)[..., None] * u.pix,
-      np.arange(3)[..., None, None]), (3, 5, 10)),
+      np.arange(3)[..., None, None] * u.pix), (3, 5, 10)),
 ])
 def test_varying_transform_4d_pc_shapes(pixel, lon_shape):
     varying_matrix_lt = [rotation_matrix(a)[:2, :2] for a in np.linspace(0, 90, 15)] * u.pix

--- a/dkist/wcs/tests/test_models.py
+++ b/dkist/wcs/tests/test_models.py
@@ -17,7 +17,13 @@ from dkist.wcs.models import (AsymmetricMapping, Ravel, Unravel, VaryingCelestia
 
 
 def test_generate_celestial():
+    shift = m.Shift(0) & m.Shift(0)
+    rot = m.AffineTransformation2D(np.array([[0, 0], [0, 0]]), translation=np.array([0, 0]))
+    scale = m.Multiply(0) & m.Multiply(0)
+    projection = m.Pix2Sky_TAN()
+    skyrot = m.RotateNative2Celestial(0, 0, 180)
     tfrm = generate_celestial_transform(
+        shift | rot | scale | projection | skyrot,
         crpix=[0, 0] * u.pix,
         crval=[0, 0] * u.arcsec,
         cdelt=[1, 1] * u.arcsec/u.pix,
@@ -42,7 +48,13 @@ def test_generate_celestial():
 
 
 def test_generate_celestial_unitless():
+    shift = m.Shift(0) & m.Shift(0)
+    rot = m.AffineTransformation2D(np.array([[0, 0], [0, 0]]), translation=np.array([0, 0]))
+    scale = m.Multiply(0) & m.Multiply(0)
+    projection = m.Pix2Sky_TAN()
+    skyrot = m.RotateNative2Celestial(0, 0, 180)
     tfrm = generate_celestial_transform(
+        shift | rot | scale | projection | skyrot,
         crpix=[0, 0],
         crval=[0, 0],
         cdelt=[1, 1],


### PR DESCRIPTION
Slightly re-jig VaryingCelestialTransform to strip units from the inputs in `._map_transform()` and then put them back afterwards. Gives a reasonable performance boost, about 3.5x faster to plot a dataset across non-optimal axes.