### PR TITLE
Add codspeed workflow to run benchmarks

### DIFF
--- a/.github/workflows/benchmark-main.yml
+++ b/.github/workflows/benchmark-main.yml
@@ -19,19 +19,17 @@ concurrency:
 
 jobs:
   benchmarks:
-    steps:
-      - name: Run benchmark
-        uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
-        with:
-          default_python: '3.10'
-          envs: |
-            - linux: benchmark-main
-      - name: Push results
-        run: |
-          cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.11-64bit/0001_main.json .tox/benchmark-main/tmp/dkist-benchmarks/main.json
-          cd .tox/benchmark-main/tmp/dkist-benchmarks
-          git add main.json
-          git commit -m "Update benchmark data for main"
-          git push origin main
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+      with:
+        default_python: '3.10'
+        envs: |
+          - linux: benchmark-main
+      # run: |
+      #   cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.11-64bit/0001_main.json .tox/benchmark-main/tmp/dkist-benchmarks/main.json
+      #   cd .tox/benchmark-main/tmp/dkist-benchmarks
+      #   git add main.json
+      #   git commit -m "Update benchmark data for main"
+      #   git push origin main
+      # secrets:
+      #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/benchmark-main.yml
+++ b/.github/workflows/benchmark-main.yml
@@ -1,0 +1,28 @@
+name: Run benchmarks for main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+  schedule:
+    #        ┌───────── minute (0 - 59)
+    #        │ ┌───────── hour (0 - 23)
+    #        │ │ ┌───────── day of the month (1 - 31)
+    #        │ │ │ ┌───────── month (1 - 12 or JAN-DEC)
+    #        │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
+    - cron: '0 9 * * 1'  # Every Monday at 0900 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmarks:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    with:
+      default_python: '3.10'
+      envs: |
+        - linux: benchmark-main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/benchmark-main.yml
+++ b/.github/workflows/benchmark-main.yml
@@ -19,10 +19,19 @@ concurrency:
 
 jobs:
   benchmarks:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
-    with:
-      default_python: '3.10'
-      envs: |
-        - linux: benchmark-main
+    steps:
+      - name: Run benchmark
+        uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+        with:
+          default_python: '3.10'
+          envs: |
+            - linux: benchmark-main
+      - name: Push results
+        run: |
+          cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.11-64bit/0001_main.json .tox/benchmark-main/tmp/dkist-benchmarks/main.json
+          cd .tox/benchmark-main/tmp/dkist-benchmarks
+          git add main.json
+          git commit -m "Update benchmark data for main"
+          git push origin main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/benchmark-main.yml
+++ b/.github/workflows/benchmark-main.yml
@@ -24,12 +24,12 @@ jobs:
         default_python: '3.10'
         envs: |
           - linux: benchmark-main
-      # run: |
-      #   cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.11-64bit/0001_main.json .tox/benchmark-main/tmp/dkist-benchmarks/main.json
-      #   cd .tox/benchmark-main/tmp/dkist-benchmarks
-      #   git add main.json
-      #   git commit -m "Update benchmark data for main"
-      #   git push origin main
+      run: |
+        cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json .tox/benchmark-main/tmp/dkist-benchmarks/main.json
+        cd .tox/benchmark-main/tmp/dkist-benchmarks
+        git add main.json
+        git commit -m "Update benchmark data for main"
+        git push origin main
       # secrets:
       #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/benchmark-main.yml
+++ b/.github/workflows/benchmark-main.yml
@@ -20,7 +20,23 @@ concurrency:
 jobs:
   benchmarks:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    container:
+      volumes:
+        - ~:/github
     with:
       default_python: '3.10'
       envs: |
         - linux: benchmark-main
+
+  update-repo:
+    runs-on: ubuntu-latest
+    container:
+      volumes:
+        - ~:/github
+    needs: [benchmarks]
+    run: |
+      git clone https://github.com/DKISTDC/dkist-benchmarks.git /github/dkist-benchmarks
+      cd /dkist-benchmarks
+      git add main.json
+      git commit -m "Update benchmark data for main"
+      git push origin main

--- a/.github/workflows/benchmark-main.yml
+++ b/.github/workflows/benchmark-main.yml
@@ -19,17 +19,8 @@ concurrency:
 
 jobs:
   benchmarks:
-      uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
-      with:
-        default_python: '3.10'
-        envs: |
-          - linux: benchmark-main
-      run: |
-        cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json .tox/benchmark-main/tmp/dkist-benchmarks/main.json
-        cd .tox/benchmark-main/tmp/dkist-benchmarks
-        git add main.json
-        git commit -m "Update benchmark data for main"
-        git push origin main
-      # secrets:
-      #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    with:
+      default_python: '3.10'
+      envs: |
+        - linux: benchmark-main

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,19 @@
+name: codspeed-benchmarks
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run benchmarks
+        uses: CodspeedHQ/action@v2
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: "pytest -vvv -r fEs --pyargs dkist -k test_benchmarks --benchmark-autosave"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
         - windows: py311-online
         - macos: py310
         - linux: py310-oldestdeps
+        - linux: benchmarks
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,6 @@ jobs:
         - windows: py311-online
         - macos: py310
         - linux: py310-oldestdeps
-        - linux: benchmarks
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/dkist/tests/test_benchmarks.py
+++ b/dkist/tests/test_benchmarks.py
@@ -1,0 +1,17 @@
+import gzip
+from pathlib import Path
+
+from dkist import load_dataset
+from dkist.data.test import rootdir
+
+
+def load_asdf_from_gzip(tmp_path_factory):
+    vispdir = tmp_path_factory.mktemp("data")
+    with gzip.open(Path(rootdir) / "large_visp.asdf.gz", mode="rb") as gfo:
+        with open(vispdir / "test_visp.asdf", mode="wb") as afo:
+            afo.write(gfo.read())
+    ds = load_dataset(vispdir / "test_visp.asdf")
+
+
+def test_load_asdf(benchmark, tmp_path_factory):
+    benchmark(load_asdf_from_gzip, tmp_path_factory)

--- a/dkist/tests/test_benchmarks.py
+++ b/dkist/tests/test_benchmarks.py
@@ -5,13 +5,13 @@ from dkist import load_dataset
 from dkist.data.test import rootdir
 
 
-def load_asdf_from_gzip(tmp_path_factory):
-    vispdir = tmp_path_factory.mktemp("data")
-    with gzip.open(Path(rootdir) / "large_visp.asdf.gz", mode="rb") as gfo:
-        with open(vispdir / "test_visp.asdf", mode="wb") as afo:
-            afo.write(gfo.read())
+def load_asdf(vispdir):
     ds = load_dataset(vispdir / "test_visp.asdf")
 
 
 def test_load_asdf(benchmark, tmp_path_factory):
-    benchmark(load_asdf_from_gzip, tmp_path_factory)
+    vispdir = tmp_path_factory.mktemp("data")
+    with gzip.open(Path(rootdir) / "large_visp.asdf.gz", mode="rb") as gfo:
+        with open(vispdir / "test_visp.asdf", mode="wb") as afo:
+            afo.write(gfo.read())
+    benchmark(load_asdf, vispdir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ tests = [
   "pytest-mpl",
   "pytest-httpserver",
   "pytest-filter-subpackage",
+  "pytest-benchmark",
   "hypothesis",
   "tox",
   "pydot",

--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ allowlist_externals = git,cp
 commands =
     git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
     {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main
-    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.11-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json
+    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json
     git -C {env_tmp_dir}/dkist-benchmarks add main.json
     git -C {env_tmp_dir}/dkist-benchmarks commit -m "Update benchmark data for main"
     git -C {env_tmp_dir}/dkist-benchmarks push origin main

--- a/tox.ini
+++ b/tox.ini
@@ -105,10 +105,3 @@ commands =
     git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
     {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main
     cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json
-    git -C {env_tmp_dir}/dkist-benchmarks add main.json
-    # Not sure what to use here but it won't commit without it so I'm using mine
-    # Obviously can change later
-    git -C {env_tmp_dir}/dkist-benchmarks config user.email "andrew.leonard@aperiosoftware.com"
-    git -C {env_tmp_dir}/dkist-benchmarks config user.name "Drew Leonard"
-    git -C {env_tmp_dir}/dkist-benchmarks commit -m "Update benchmark data for main"
-    git -C {env_tmp_dir}/dkist-benchmarks push origin main

--- a/tox.ini
+++ b/tox.ini
@@ -102,6 +102,5 @@ commands =
 description = Run benchmarks on main to keep comparison data up to date
 allowlist_externals = git,cp
 commands =
-    git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
     {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main
-    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json
+    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json /github/main.json

--- a/tox.ini
+++ b/tox.ini
@@ -104,4 +104,4 @@ allowlist_externals = git,cp
 commands =
     git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
     {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main
-    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.11-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json
+    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json

--- a/tox.ini
+++ b/tox.ini
@@ -90,17 +90,3 @@ commands =
     !notebooks: sphinx-build -j 1 --color -W --keep-going -b html -d _build/.doctrees . _build/html -D nb_execution_mode=off {posargs}
     notebooks: sphinx-build -j 1 --color -W --keep-going -b html -d _build/.doctrees . _build/html {posargs}
     python -c 'import pathlib; print("Documentation available under file://\{0\}".format(pathlib.Path(r"{toxinidir}") / "docs" / "_build" / "index.html"))'
-
-[testenv:benchmarks]
-description = Run benchmarks on PR and compare against main to ensure there are no performance regressions
-allowlist_externals=git
-commands =
-    git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
-    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-autosave --benchmark-compare={env_tmp_dir}/dkist-benchmarks/main.json --benchmark-compare-fail=mean:5%
-
-[testenv:benchmark-main]
-description = Run benchmarks on main to keep comparison data up to date
-allowlist_externals = git,cp
-commands =
-    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main
-    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json /github/main.json

--- a/tox.ini
+++ b/tox.ini
@@ -106,5 +106,9 @@ commands =
     {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main
     cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json
     git -C {env_tmp_dir}/dkist-benchmarks add main.json
+    # Not sure what to use here but it won't commit without it so I'm using mine
+    # Obviously can change later
+    git -C {env_tmp_dir}/dkist-benchmarks config user.email "andrew.leonard@aperiosoftware.com"
+    git -C {env_tmp_dir}/dkist-benchmarks config user.name "Drew Leonard"
     git -C {env_tmp_dir}/dkist-benchmarks commit -m "Update benchmark data for main"
     git -C {env_tmp_dir}/dkist-benchmarks push origin main

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     py310-oldestdeps
     build_docs{,-notebooks}
     codestyle
+    benchmarks
 
 [testenv]
 pypi_filter = https://raw.githubusercontent.com/sunpy/sunpy/main/.test_package_pins.txt
@@ -89,3 +90,8 @@ commands =
     !notebooks: sphinx-build -j 1 --color -W --keep-going -b html -d _build/.doctrees . _build/html -D nb_execution_mode=off {posargs}
     notebooks: sphinx-build -j 1 --color -W --keep-going -b html -d _build/.doctrees . _build/html {posargs}
     python -c 'import pathlib; print("Documentation available under file://\{0\}".format(pathlib.Path(r"{toxinidir}") / "docs" / "_build" / "index.html"))'
+
+[testenv:benchmarks]
+description = Run benchmarks against latest release to ensure there are no performance regressions
+commands =
+    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-autosave --benchmark-compare=0001

--- a/tox.ini
+++ b/tox.ini
@@ -101,6 +101,9 @@ commands =
 [testenv:benchmark-main]
 description = Run benchmarks on main to keep comparison data up to date
 allowlist_externals = git,cp
+set_env =
+    PYTEST_COMMAND = pytest -vvv -r fEs --pyargs dkist --cov-report=xml --cov=dkist --cov-config={toxinidir}/.coveragerc {toxinidir}/docs
+    GIT_TERMINAL_PROMPT = 0
 commands =
     git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
     {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main
@@ -111,4 +114,4 @@ commands =
     git -C {env_tmp_dir}/dkist-benchmarks config user.email "andrew.leonard@aperiosoftware.com"
     git -C {env_tmp_dir}/dkist-benchmarks config user.name "Drew Leonard"
     git -C {env_tmp_dir}/dkist-benchmarks commit -m "Update benchmark data for main"
-    git -C {env_tmp_dir}/dkist-benchmarks push origin main --verbose
+    git -C {env_tmp_dir}/dkist-benchmarks push origin main

--- a/tox.ini
+++ b/tox.ini
@@ -111,4 +111,4 @@ commands =
     git -C {env_tmp_dir}/dkist-benchmarks config user.email "andrew.leonard@aperiosoftware.com"
     git -C {env_tmp_dir}/dkist-benchmarks config user.name "Drew Leonard"
     git -C {env_tmp_dir}/dkist-benchmarks commit -m "Update benchmark data for main"
-    git -C {env_tmp_dir}/dkist-benchmarks push origin main
+    git -C {env_tmp_dir}/dkist-benchmarks push origin main --verbose

--- a/tox.ini
+++ b/tox.ini
@@ -100,8 +100,8 @@ commands =
 
 [testenv:benchmark-main]
 description = Run benchmarks on main to keep comparison data up to date
-allowlist_externals=git
+allowlist_externals = git,cp
 commands =
     git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
-    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-autosave
-    cp {toxinidir}/.tmp/benchmark-main/tmp/.benchmarks/Linux-*/0001_*.json {env_tmp_dir}/dkist-benchmarks/main.json
+    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main
+    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.11-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json

--- a/tox.ini
+++ b/tox.ini
@@ -93,5 +93,7 @@ commands =
 
 [testenv:benchmarks]
 description = Run benchmarks against latest release to ensure there are no performance regressions
+allowlist_externals=git
 commands =
-    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-autosave --benchmark-compare=0001
+    git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
+    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-storage=tmp --benchmark-autosave --benchmark-compare={env_tmp_dir}/dkist-benchmarks/v1.5.0.json

--- a/tox.ini
+++ b/tox.ini
@@ -101,9 +101,6 @@ commands =
 [testenv:benchmark-main]
 description = Run benchmarks on main to keep comparison data up to date
 allowlist_externals = git,cp
-set_env =
-    PYTEST_COMMAND = pytest -vvv -r fEs --pyargs dkist --cov-report=xml --cov=dkist --cov-config={toxinidir}/.coveragerc {toxinidir}/docs
-    GIT_TERMINAL_PROMPT = 0
 commands =
     git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
     {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main

--- a/tox.ini
+++ b/tox.ini
@@ -92,8 +92,16 @@ commands =
     python -c 'import pathlib; print("Documentation available under file://\{0\}".format(pathlib.Path(r"{toxinidir}") / "docs" / "_build" / "index.html"))'
 
 [testenv:benchmarks]
-description = Run benchmarks against latest release to ensure there are no performance regressions
+description = Run benchmarks on PR and compare against main to ensure there are no performance regressions
 allowlist_externals=git
 commands =
     git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
-    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-storage=tmp --benchmark-autosave --benchmark-compare={env_tmp_dir}/dkist-benchmarks/v1.5.0.json
+    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-autosave --benchmark-compare={env_tmp_dir}/dkist-benchmarks/main.json --benchmark-compare-fail=mean:5%
+
+[testenv:benchmark-main]
+description = Run benchmarks on main to keep comparison data up to date
+allowlist_externals=git
+commands =
+    git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
+    {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-autosave
+    cp {toxinidir}/.tmp/benchmark-main/tmp/.benchmarks/Linux-*/0001_*.json {env_tmp_dir}/dkist-benchmarks/main.json

--- a/tox.ini
+++ b/tox.ini
@@ -104,4 +104,7 @@ allowlist_externals = git,cp
 commands =
     git clone https://github.com/DKISTDC/dkist-benchmarks.git {env_tmp_dir}/dkist-benchmarks
     {env:PYTEST_COMMAND} -k test_benchmarks --benchmark-save=main
-    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.10-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json
+    cp {toxinidir}/.tmp/benchmark-main/.benchmarks/Linux-CPython-3.11-64bit/0001_main.json {env_tmp_dir}/dkist-benchmarks/main.json
+    git -C {env_tmp_dir}/dkist-benchmarks add main.json
+    git -C {env_tmp_dir}/dkist-benchmarks commit -m "Update benchmark data for main"
+    git -C {env_tmp_dir}/dkist-benchmarks push origin main


### PR DESCRIPTION
Adds a workflow to run [Codspeed](https://codspeed.io/). Supercedes #372 , as this will hopefully be easier to setup and maintain, and give nicer output, a la codecov.