### PR TITLE
Fitsio loader

### DIFF
--- a/dkist/conftest.py
+++ b/dkist/conftest.py
@@ -22,7 +22,7 @@ from dkist.data.test import rootdir
 from dkist.dataset import Dataset
 from dkist.dataset.tiled_dataset import TiledDataset
 from dkist.io import FileManager
-from dkist.io.loaders import AstropyFITSLoader
+from dkist.io.loaders import FitsioFITSLoader
 
 
 @pytest.fixture
@@ -232,7 +232,7 @@ def dataset(array, identity_gwcs):
     # Construct the filename here as a scalar array to make sure that works as
     # it's what dkist-inventory does
     ds._file_manager = FileManager.from_parts(np.array("test1.fits"), 0, "float", array.shape,
-                                              loader=AstropyFITSLoader)
+                                              loader=FitsioFITSLoader)
 
     return ds
 

--- a/dkist/io/asdf/converters/file_manager.py
+++ b/dkist/io/asdf/converters/file_manager.py
@@ -13,7 +13,7 @@ class FileManagerConverter(Converter):
 
     def from_yaml_tree(self, node, tag, ctx):
         from dkist.io.file_manager import FileManager
-        from dkist.io.loaders import AstropyFITSLoader
+        from dkist.io.loaders import FitsioFITSLoader
 
         url = urlparse(ctx.url or ".")
         if url.scheme not in ("file", ""):
@@ -29,7 +29,7 @@ class FileManagerConverter(Converter):
                                               node["datatype"],
                                               node["shape"],
                                               chunksize=node.get("chunksize", None),
-                                              loader=AstropyFITSLoader,
+                                              loader=FitsioFITSLoader,
                                               basepath=base_path)
 
     def to_yaml_tree(self, obj, tag, ctx):

--- a/dkist/io/asdf/tests/test_dataset.py
+++ b/dkist/io/asdf/tests/test_dataset.py
@@ -12,7 +12,7 @@ from asdf.testing.helpers import roundtrip_object
 import dkist
 from dkist.data.test import rootdir
 from dkist.io import FileManager
-from dkist.io.loaders import AstropyFITSLoader
+from dkist.io.loaders import FitsioFITSLoader
 
 
 @pytest.fixture
@@ -26,7 +26,7 @@ def tagobj(request):
 @pytest.fixture
 def file_manager():
     return FileManager.from_parts(["test1.fits", "test2.fits"], 0, "float", (10, 10),
-                                  loader=AstropyFITSLoader)
+                                  loader=FitsioFITSLoader)
 
 
 def test_roundtrip_file_manager(file_manager):

--- a/dkist/io/tests/test_fits.py
+++ b/dkist/io/tests/test_fits.py
@@ -8,7 +8,7 @@ import asdf
 
 from dkist.data.test import rootdir
 from dkist.io.file_manager import FileManager
-from dkist.io.loaders import AstropyFITSLoader
+from dkist.io.loaders import FitsioFITSLoader
 
 eitdir = Path(rootdir) / "EIT"
 
@@ -34,7 +34,7 @@ def relative_ac(relative_ear):
                                   relative_ear.target,
                                   relative_ear.dtype,
                                   relative_ear.shape,
-                                  loader=AstropyFITSLoader,
+                                  loader=FitsioFITSLoader,
                                   basepath=eitdir)
 
 
@@ -49,7 +49,7 @@ def absolute_ac(absolute_ear):
                                   absolute_ear.target,
                                   absolute_ear.dtype,
                                   absolute_ear.shape,
-                                  loader=AstropyFITSLoader,
+                                  loader=FitsioFITSLoader,
                                   basepath=eitdir)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,8 @@ deps =
     devdeps: git+https://github.com/astropy/asdf-astropy
     # Autogenerate oldest dependencies from info in setup.cfg
     oldestdeps: minimum_dependencies
+    # benchmark tests want fitsio for the new loader
+    benchmarks: fitsio
 # The following indicates which extras_require will be installed
 extras =
     tests


### PR DESCRIPTION
Closes #159 

Adds a FITS loader that uses fitsio. Currently replaces the astropy loader but that's just until I've sorted out the config stuff for switching between them. Mostly making the PR to see how the benchmarks respond because if it's just as slow there's not much point (or the benchmarks don't cover it properly).