### PR TITLE
Plotting helpers for TiledDataset

### DIFF
--- a/.circleci/codecov_upload.sh
+++ b/.circleci/codecov_upload.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl -Os https://uploader.codecov.io/latest/linux/codecov
+curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+shasum -a 256 -c codecov.SHA256SUM
+chmod +x codecov
+./codecov "$@"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,9 @@ jobs:
       - run: *apt-install
       - run: pip install --user -U tox tox-pypi-filter
       - run: tox -v
-      # - run:
-      #     name: Running codecov
-      #     command: bash -e .circleci/codecov_upload.sh -f ".tmp/${TOXENV}/coverage.xml"
+      - run:
+          name: Running codecov
+          command: bash -e .circleci/codecov_upload.sh -f ".tmp/${TOXENV}/coverage.xml"
       - store_artifacts:
           path: .tmp/<< parameters.jobname >>/figure_test_images
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
         type: string
     docker:
       - image: cimg/python:3.12
-    resource_class: large
     environment:
       TOXENV=<< parameters.jobname >>
     steps:
@@ -56,7 +55,6 @@ jobs:
         type: string
     docker:
       - image: cimg/python:3.12
-    resource_class: large
     environment:
       TOXENV: << parameters.jobname >>
       GIT_SSH_COMMAND: ssh -i ~/.ssh/id_rsa_7b8fc81c13a3b446ec9aa50d3f626978

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
         type: string
     docker:
       - image: cimg/python:3.12
+    resource_class: large
     environment:
       TOXENV=<< parameters.jobname >>
     steps:
@@ -55,6 +56,7 @@ jobs:
         type: string
     docker:
       - image: cimg/python:3.12
+    resource_class: large
     environment:
       TOXENV: << parameters.jobname >>
       GIT_SSH_COMMAND: ssh -i ~/.ssh/id_rsa_7b8fc81c13a3b446ec9aa50d3f626978

--- a/changelog/408.feature.rst
+++ b/changelog/408.feature.rst
@@ -1,0 +1,1 @@
+Add `TiledDataset.plot()` quicklook method.

--- a/dkist/data/_sample.py
+++ b/dkist/data/_sample.py
@@ -57,7 +57,7 @@ def _download_and_extract_sample_data(names, overwrite, path):
     for i, tarpath in enumerate(results):
         output_path = path / file_folder[Path(tarpath).name]
         with tarfile.open(tarpath, "r:*") as tar:
-            tar.extractall(path=output_path, filter="data")
+            tar.extractall(path=output_path, filter=tarfile.fully_trusted_filter)
         results[i] = output_path
 
     return results

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -1,5 +1,6 @@
 import copy
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -59,3 +60,10 @@ def test_tiled_dataset_from_components(dataset):
         assert ds.files == fm
         assert ds.meta["inventory"] is inventory
         assert ds.meta["headers"] is headers
+
+
+@pytest.mark.mpl_image_compare
+@pytest.mark.parametrize("share_scale", [True, False])
+def test_plot(large_tiled_dataset, share_scale):
+    large_tiled_dataset.plot(0, share_scale=share_scale)
+    return plt.gcf()

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from dkist import Dataset, TiledDataset, load_dataset
+from dkist.tests.helpers import figure_test
 
 
 def test_tiled_dataset(simple_tiled_dataset, dataset):
@@ -62,7 +63,8 @@ def test_tiled_dataset_from_components(dataset):
         assert ds.meta["headers"] is headers
 
 
-@pytest.mark.mpl_image_compare
+# @pytest.mark.mpl_image_compare
+@figure_test
 @pytest.mark.parametrize("share_scale", [True, False])
 def test_plot(share_scale):
     from dkist.data.sample import VBI_AJQWW

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -69,6 +69,10 @@ def test_tiled_dataset_from_components(dataset):
 def test_plot(share_scale):
     from dkist.data.sample import VBI_AJQWW
     ds = load_dataset(VBI_AJQWW)
+    newtiles = []
+    for tile in ds.flat:
+        newtiles.append(tile.rebin((1, 4, 4), operation=np.sum))
+    ds = TiledDataset(np.array(newtiles).reshape(ds.shape), inventory=ds.inventory)
     fig = plt.figure(figsize=(600, 800))
     ds.plot(0, share_scale=share_scale)
     return plt.gcf()

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 
 from dkist import Dataset, TiledDataset, load_dataset
-from dkist.data.sample import VBI_AJQWW
 
 
 def test_tiled_dataset(simple_tiled_dataset, dataset):
@@ -66,6 +65,7 @@ def test_tiled_dataset_from_components(dataset):
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("share_scale", [True, False])
 def test_plot(share_scale):
+    from dkist.data.sample import VBI_AJQWW
     ds = load_dataset(VBI_AJQWW)
     ds.plot(0, share_scale=share_scale)
     return plt.gcf()

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -71,7 +71,7 @@ def test_plot(share_scale):
     ds = load_dataset(VBI_AJQWW)
     newtiles = []
     for tile in ds.flat:
-        newtiles.append(tile.rebin((1, 4, 4), operation=np.sum))
+        newtiles.append(tile.rebin((1, 8, 8), operation=np.sum))
     ds = TiledDataset(np.array(newtiles).reshape(ds.shape), inventory=ds.inventory)
     fig = plt.figure(figsize=(600, 800))
     ds.plot(0, share_scale=share_scale)

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -4,7 +4,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from dkist import Dataset, TiledDataset
+from dkist import Dataset, TiledDataset, load_dataset
+from dkist.data.sample import VBI_AJQWW, download_all_sample_data
 
 
 def test_tiled_dataset(simple_tiled_dataset, dataset):
@@ -64,6 +65,8 @@ def test_tiled_dataset_from_components(dataset):
 
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("share_scale", [True, False])
-def test_plot(large_tiled_dataset, share_scale):
-    large_tiled_dataset.plot(0, share_scale=share_scale)
+def test_plot(share_scale):
+    download_all_sample_data()
+    ds = load_dataset(VBI_AJQWW)
+    ds.plot(0, share_scale=share_scale)
     return plt.gcf()

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -67,5 +67,6 @@ def test_tiled_dataset_from_components(dataset):
 def test_plot(share_scale):
     from dkist.data.sample import VBI_AJQWW
     ds = load_dataset(VBI_AJQWW)
+    fig = plt.figure(figsize=(600, 800))
     ds.plot(0, share_scale=share_scale)
     return plt.gcf()

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from dkist import Dataset, TiledDataset, load_dataset
-from dkist.data.sample import VBI_AJQWW, download_all_sample_data
+from dkist.data.sample import VBI_AJQWW
 
 
 def test_tiled_dataset(simple_tiled_dataset, dataset):
@@ -66,7 +66,6 @@ def test_tiled_dataset_from_components(dataset):
 @pytest.mark.mpl_image_compare
 @pytest.mark.parametrize("share_scale", [True, False])
 def test_plot(share_scale):
-    download_all_sample_data()
     ds = load_dataset(VBI_AJQWW)
     ds.plot(0, share_scale=share_scale)
     return plt.gcf()

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -63,7 +63,6 @@ def test_tiled_dataset_from_components(dataset):
         assert ds.meta["headers"] is headers
 
 
-# @pytest.mark.mpl_image_compare
 @figure_test
 @pytest.mark.parametrize("share_zscale", [True, False], ids=["share_zscale", "indpendent_zscale"])
 def test_tileddataset_plot(share_zscale):

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -65,8 +65,8 @@ def test_tiled_dataset_from_components(dataset):
 
 # @pytest.mark.mpl_image_compare
 @figure_test
-@pytest.mark.parametrize("share_scale", [True, False])
-def test_plot(share_scale):
+@pytest.mark.parametrize("share_zscale", [True, False], ids=["share_zscale", "indpendent_zscale"])
+def test_tileddataset_plot(share_zscale):
     from dkist.data.sample import VBI_AJQWW
     ds = load_dataset(VBI_AJQWW)
     newtiles = []

--- a/dkist/dataset/tests/test_tiled_dataset.py
+++ b/dkist/dataset/tests/test_tiled_dataset.py
@@ -73,5 +73,5 @@ def test_tileddataset_plot(share_zscale):
         newtiles.append(tile.rebin((1, 8, 8), operation=np.sum))
     ds = TiledDataset(np.array(newtiles).reshape(ds.shape), inventory=ds.inventory)
     fig = plt.figure(figsize=(600, 800))
-    ds.plot(0, share_scale=share_scale)
+    ds.plot(0, share_zscale=share_zscale)
     return plt.gcf()

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -130,8 +130,7 @@ class TiledDataset(Collection):
         for i, tile in enumerate(self.flat):
             ax = fig.add_subplot(self.shape[0], self.shape[1], i+1, projection=tile[0].wcs)
             ax.set_title(f"MINDEX1={tile.headers[0]['MINDEX1']}, MINDEX2={tile.headers[0]['MINDEX2']}")
-            tile.plot(axes=ax)
-
+            tile[0].plot(axes=ax)
         return fig
 
     # TODO: def regrid()

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -148,7 +148,7 @@ class TiledDataset(Collection):
             for ax in fig.get_axes():
                 ax.get_images()[0].set_clim(vmin, vmax)
         timestamp = self[0, 0].axis_world_coords("time")[-1].iso[slice_index]
-        fig.suptitle(f"TiledDataset {self.inventory['datasetId']} at time {timestamp} (slice={slice_index})", y=0.95)
+        fig.suptitle(f"{self.inventory['instrumentName']} Dataset ({self.inventory['datasetId']}) at time {timestamp} (slice={slice_index})", y=0.95)
         return fig
 
     # TODO: def regrid()

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -7,6 +7,7 @@ not contiguous in the spatial dimensions (due to overlaps and offsets).
 """
 from collections.abc import Collection
 
+import matplotlib.pyplot as plt
 import numpy as np
 
 from astropy.table import vstack
@@ -124,5 +125,13 @@ class TiledDataset(Collection):
         """
         return self._data.shape
 
-    # TODO: def plot()
+    def plot(self):
+        fig = plt.figure()
+        for i, tile in enumerate(self.flat):
+            ax = fig.add_subplot(self.shape[0], self.shape[1], i+1)#, projection=tile.wcs)
+            ax.set_title(f"MINDEX1={tile.headers[0]['MINDEX1']}, MINDEX2={tile.headers[0]['MINDEX2']}")
+            tile.plot(axes=ax)
+
+        return fig
+
     # TODO: def regrid()

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -125,12 +125,12 @@ class TiledDataset(Collection):
         """
         return self._data.shape
 
-    def plot(self):
+    def plot(self, slice_index: int):
         fig = plt.figure()
         for i, tile in enumerate(self.flat):
             ax = fig.add_subplot(self.shape[0], self.shape[1], i+1, projection=tile[0].wcs)
-            ax.set_title(f"MINDEX1={tile.headers[0]['MINDEX1']}, MINDEX2={tile.headers[0]['MINDEX2']}")
-            tile[0].plot(axes=ax)
+            ax.set_title(f"MINDEX1={tile.headers[slice_index]['MINDEX1']}, MINDEX2={tile.headers[slice_index]['MINDEX2']}")
+            tile[slice_index].plot(axes=ax)
             if i != 3:
                 ax.set_ylabel(" ")
             if i != 7:

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -125,12 +125,12 @@ class TiledDataset(Collection):
         """
         return self._data.shape
 
-    def plot(self, slice_index: int):
+    def plot(self, slice_index: int, **kwargs):
         fig = plt.figure()
         for i, tile in enumerate(self.flat):
             ax = fig.add_subplot(self.shape[0], self.shape[1], i+1, projection=tile[0].wcs)
             ax.set_title(f"MINDEX1={tile.headers[slice_index]['MINDEX1']}, MINDEX2={tile.headers[slice_index]['MINDEX2']}")
-            tile[slice_index].plot(axes=ax)
+            tile[slice_index].plot(axes=ax, **kwargs)
             if i != 3:
                 ax.set_ylabel(" ")
             if i != 7:

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -129,7 +129,6 @@ class TiledDataset(Collection):
         fig = plt.figure()
         for i, tile in enumerate(self.flat):
             ax = fig.add_subplot(self.shape[0], self.shape[1], i+1, projection=tile[0].wcs)
-            ax.set_title(f"MINDEX1={tile.headers[slice_index]['MINDEX1']}, MINDEX2={tile.headers[slice_index]['MINDEX2']}")
             tile[slice_index].plot(axes=ax, **kwargs)
             if i == 0:
                 xlabel = ax.coords[0].get_axislabel() or ax.coords[0]._get_default_axislabel()
@@ -141,6 +140,8 @@ class TiledDataset(Collection):
                         fig.supylabel(ylabel, x=0.05)
             ax.set_ylabel(" ")
             ax.set_xlabel(" ")
+        timestamp = self[0, 0].axis_world_coords(0)[-1].iso[slice_index]
+        fig.suptitle(f"TiledDataset {self.inventory['datasetId']} at time {timestamp} (slice={slice_index})", y=0.95)
         return fig
 
     # TODO: def regrid()

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -131,6 +131,10 @@ class TiledDataset(Collection):
             ax = fig.add_subplot(self.shape[0], self.shape[1], i+1, projection=tile[0].wcs)
             ax.set_title(f"MINDEX1={tile.headers[0]['MINDEX1']}, MINDEX2={tile.headers[0]['MINDEX2']}")
             tile[0].plot(axes=ax)
+            if i != 3:
+                ax.set_ylabel(" ")
+            if i != 7:
+                ax.set_xlabel(" ")
         return fig
 
     # TODO: def regrid()

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -125,7 +125,7 @@ class TiledDataset(Collection):
         """
         return self._data.shape
 
-    def plot(self, slice_index: int, share_scale=False, **kwargs):
+    def plot(self, slice_index: int, share_zscale=False, **kwargs):
         vmin, vmax = np.inf, 0
         fig = plt.figure()
         for i, tile in enumerate(self.flat):
@@ -144,7 +144,7 @@ class TiledDataset(Collection):
             vmax = axmax if axmax > vmax else vmax
             ax.set_ylabel(" ")
             ax.set_xlabel(" ")
-        if share_scale:
+        if share_zscale:
             for ax in fig.get_axes():
                 ax.get_images()[0].set_clim(vmin, vmax)
         timestamp = self[0, 0].axis_world_coords("time")[-1].iso[slice_index]

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -128,7 +128,7 @@ class TiledDataset(Collection):
     def plot(self):
         fig = plt.figure()
         for i, tile in enumerate(self.flat):
-            ax = fig.add_subplot(self.shape[0], self.shape[1], i+1)#, projection=tile.wcs)
+            ax = fig.add_subplot(self.shape[0], self.shape[1], i+1, projection=tile[0].wcs)
             ax.set_title(f"MINDEX1={tile.headers[0]['MINDEX1']}, MINDEX2={tile.headers[0]['MINDEX2']}")
             tile.plot(axes=ax)
 

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -125,7 +125,8 @@ class TiledDataset(Collection):
         """
         return self._data.shape
 
-    def plot(self, slice_index: int, **kwargs):
+    def plot(self, slice_index: int, share_scale=False, **kwargs):
+        vmin, vmax = np.inf, 0
         fig = plt.figure()
         for i, tile in enumerate(self.flat):
             ax = fig.add_subplot(self.shape[0], self.shape[1], i+1, projection=tile[0].wcs)
@@ -138,8 +139,14 @@ class TiledDataset(Collection):
                         fig.supxlabel(xlabel, y=0.05)
                     if "l" in coord.axislabels.get_visible_axes():
                         fig.supylabel(ylabel, x=0.05)
+            axmin, axmax = ax.get_images()[0].get_clim()
+            vmin = axmin if axmin < vmin else vmin
+            vmax = axmax if axmax > vmax else vmax
             ax.set_ylabel(" ")
             ax.set_xlabel(" ")
+        if share_scale:
+            for ax in fig.get_axes():
+                ax.get_images()[0].set_clim(vmin, vmax)
         timestamp = self[0, 0].axis_world_coords(0)[-1].iso[slice_index]
         fig.suptitle(f"TiledDataset {self.inventory['datasetId']} at time {timestamp} (slice={slice_index})", y=0.95)
         return fig

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -147,7 +147,7 @@ class TiledDataset(Collection):
         if share_scale:
             for ax in fig.get_axes():
                 ax.get_images()[0].set_clim(vmin, vmax)
-        timestamp = self[0, 0].axis_world_coords(0)[-1].iso[slice_index]
+        timestamp = self[0, 0].axis_world_coords("time")[-1].iso[slice_index]
         fig.suptitle(f"TiledDataset {self.inventory['datasetId']} at time {timestamp} (slice={slice_index})", y=0.95)
         return fig
 

--- a/dkist/dataset/tiled_dataset.py
+++ b/dkist/dataset/tiled_dataset.py
@@ -131,10 +131,16 @@ class TiledDataset(Collection):
             ax = fig.add_subplot(self.shape[0], self.shape[1], i+1, projection=tile[0].wcs)
             ax.set_title(f"MINDEX1={tile.headers[slice_index]['MINDEX1']}, MINDEX2={tile.headers[slice_index]['MINDEX2']}")
             tile[slice_index].plot(axes=ax, **kwargs)
-            if i != 3:
-                ax.set_ylabel(" ")
-            if i != 7:
-                ax.set_xlabel(" ")
+            if i == 0:
+                xlabel = ax.coords[0].get_axislabel() or ax.coords[0]._get_default_axislabel()
+                ylabel = ax.coords[1].get_axislabel() or ax.coords[1]._get_default_axislabel()
+                for coord in ax.coords:
+                    if "b" in coord.axislabels.get_visible_axes():
+                        fig.supxlabel(xlabel, y=0.05)
+                    if "l" in coord.axislabels.get_visible_axes():
+                        fig.supylabel(ylabel, x=0.05)
+            ax.set_ylabel(" ")
+            ax.set_xlabel(" ")
         return fig
 
     # TODO: def regrid()

--- a/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
+++ b/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
@@ -6,6 +6,6 @@
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice1]": "cbb84fbae51d8238803f8f0d6820c575f024fe54b1656f1b181dc4ec645e9ff9",
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice2]": "132c5615832daff457dacb4cb770498f1fbb4460a5b90b5d4d01d224c70eeb28",
   "dkist.dataset.tests.test_plotting.test_2d_plot2": "409b5a10ad8ccf005331261505e63ce8febdc38eb8b5a34f8863e567e3cccb9c",
-  "dkist.dataset.tests.test_tiled_dataset.test_tileddataset_plot[share_zscale]": "1d7b4a34ff6af242460934b8ff4b7d41adcd626eca6993b8ce51d8215043bcdb",
-  "dkist.dataset.tests.test_tiled_dataset.test_tileddataset_plot[indpendent_zscale]": "5ac0baf18c66b87107fde794b0b6fae4cf1d78b01d31a5fbe84c23a00df4e19b"
+  "dkist.dataset.tests.test_tiled_dataset.test_tileddataset_plot[share_zscale]": "08d480bf75e3461a3eb09b0fb78ac9a7e88ac6d80194f15a58ef531c7fc2bb53",
+  "dkist.dataset.tests.test_tiled_dataset.test_tileddataset_plot[indpendent_zscale]": "4d767a558ab1e0bd1bfeac5b8311a236e0ddcee484ae2b49cf32ffa8f0a4a93a"
 }

--- a/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
+++ b/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
@@ -6,6 +6,6 @@
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice1]": "cbb84fbae51d8238803f8f0d6820c575f024fe54b1656f1b181dc4ec645e9ff9",
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice2]": "132c5615832daff457dacb4cb770498f1fbb4460a5b90b5d4d01d224c70eeb28",
   "dkist.dataset.tests.test_plotting.test_2d_plot2": "409b5a10ad8ccf005331261505e63ce8febdc38eb8b5a34f8863e567e3cccb9c",
-  "dkist.dataset.tests.test_tiled_dataset.test_plot[True]": "1c59da7870efc491cbf2006097cd32bfa11321e1e7cdf9000d0d927dd1ab3520",
-  "dkist.dataset.tests.test_tiled_dataset.test_plot[False]": "caf112e2616554c6ba2db0af451cb0b232f074fbd68d99d63787962c74cf7910"
+  "dkist.dataset.tests.test_tiled_dataset.test_plot[True]": "1d7b4a34ff6af242460934b8ff4b7d41adcd626eca6993b8ce51d8215043bcdb",
+  "dkist.dataset.tests.test_tiled_dataset.test_plot[False]": "5ac0baf18c66b87107fde794b0b6fae4cf1d78b01d31a5fbe84c23a00df4e19b"
 }

--- a/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
+++ b/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
@@ -6,6 +6,6 @@
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice1]": "cbb84fbae51d8238803f8f0d6820c575f024fe54b1656f1b181dc4ec645e9ff9",
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice2]": "132c5615832daff457dacb4cb770498f1fbb4460a5b90b5d4d01d224c70eeb28",
   "dkist.dataset.tests.test_plotting.test_2d_plot2": "409b5a10ad8ccf005331261505e63ce8febdc38eb8b5a34f8863e567e3cccb9c",
-  "dkist.dataset.tests.test_tiled_dataset.test_plot[True]": "1d7b4a34ff6af242460934b8ff4b7d41adcd626eca6993b8ce51d8215043bcdb",
-  "dkist.dataset.tests.test_tiled_dataset.test_plot[False]": "5ac0baf18c66b87107fde794b0b6fae4cf1d78b01d31a5fbe84c23a00df4e19b"
+  "dkist.dataset.tests.test_tiled_dataset.test_tileddataset_plot[share_zscale]": "1d7b4a34ff6af242460934b8ff4b7d41adcd626eca6993b8ce51d8215043bcdb",
+  "dkist.dataset.tests.test_tiled_dataset.test_tileddataset_plot[indpendent_zscale]": "5ac0baf18c66b87107fde794b0b6fae4cf1d78b01d31a5fbe84c23a00df4e19b"
 }

--- a/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
+++ b/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
@@ -6,6 +6,6 @@
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice1]": "cbb84fbae51d8238803f8f0d6820c575f024fe54b1656f1b181dc4ec645e9ff9",
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice2]": "132c5615832daff457dacb4cb770498f1fbb4460a5b90b5d4d01d224c70eeb28",
   "dkist.dataset.tests.test_plotting.test_2d_plot2": "409b5a10ad8ccf005331261505e63ce8febdc38eb8b5a34f8863e567e3cccb9c",
-  "dkist.dataset.tests.test_tiled_dataset.test_plot[True]": "88b09788a1a4742018779a7a7f9e4bb64e1e9a2871af3f9516e49532d883c186",
-  "dkist.dataset.tests.test_tiled_dataset.test_plot[False]": "a40e61ddef52f4f33495b10b71c333a8705e79b530e04353604205d20d180cc8"
+  "dkist.dataset.tests.test_tiled_dataset.test_plot[True]": "1c59da7870efc491cbf2006097cd32bfa11321e1e7cdf9000d0d927dd1ab3520",
+  "dkist.dataset.tests.test_tiled_dataset.test_plot[False]": "caf112e2616554c6ba2db0af451cb0b232f074fbd68d99d63787962c74cf7910"
 }

--- a/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
+++ b/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
@@ -5,5 +5,7 @@
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice0]": "b31423d5ec45941849564f4ec7e276f2c52a0fa5038ce0b3c8d4af1b7f848a1d",
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice1]": "cbb84fbae51d8238803f8f0d6820c575f024fe54b1656f1b181dc4ec645e9ff9",
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice2]": "132c5615832daff457dacb4cb770498f1fbb4460a5b90b5d4d01d224c70eeb28",
-  "dkist.dataset.tests.test_plotting.test_2d_plot2": "409b5a10ad8ccf005331261505e63ce8febdc38eb8b5a34f8863e567e3cccb9c"
+  "dkist.dataset.tests.test_plotting.test_2d_plot2": "409b5a10ad8ccf005331261505e63ce8febdc38eb8b5a34f8863e567e3cccb9c",
+  "dkist.dataset.tests.test_tiled_dataset.test_plot[True]": "6887cd6ae6d76acc61b6719e09abefa92818c1f0b5adfb5a18d6143912d26609",
+  "dkist.dataset.tests.test_tiled_dataset.test_plot[False]": "2262a9fdc8328355dc7a90d9590dc60921f4dffd454e67854482c3f82b139574"
 }

--- a/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
+++ b/dkist/tests/figure_hashes_mpl_391_ft_261_astropy_611_animators_111_ndcube_222.json
@@ -6,6 +6,6 @@
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice1]": "cbb84fbae51d8238803f8f0d6820c575f024fe54b1656f1b181dc4ec645e9ff9",
   "dkist.dataset.tests.test_plotting.test_2d_plot[aslice2]": "132c5615832daff457dacb4cb770498f1fbb4460a5b90b5d4d01d224c70eeb28",
   "dkist.dataset.tests.test_plotting.test_2d_plot2": "409b5a10ad8ccf005331261505e63ce8febdc38eb8b5a34f8863e567e3cccb9c",
-  "dkist.dataset.tests.test_tiled_dataset.test_plot[True]": "6887cd6ae6d76acc61b6719e09abefa92818c1f0b5adfb5a18d6143912d26609",
-  "dkist.dataset.tests.test_tiled_dataset.test_plot[False]": "2262a9fdc8328355dc7a90d9590dc60921f4dffd454e67854482c3f82b139574"
+  "dkist.dataset.tests.test_tiled_dataset.test_plot[True]": "88b09788a1a4742018779a7a7f9e4bb64e1e9a2871af3f9516e49532d883c186",
+  "dkist.dataset.tests.test_tiled_dataset.test_plot[False]": "a40e61ddef52f4f33495b10b71c333a8705e79b530e04353604205d20d180cc8"
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -31,6 +31,7 @@ addopts =
     --doctest-rst
     -p no:unraisableexception
     -p no:threadexception
+    -m "not mpl_image_compare"
 mpl-results-path = figure_test_images
 mpl-deterministic = true
 filterwarnings =

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ extras =
 commands_pre =
     oldestdeps: minimum_dependencies dkist --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt cryptography<42 jsonschema==4.0.1
+    figure: python -c "from dkist.data.sample import download_all_sample_data; download_all_sample_data()"
     pip freeze --all --no-input
 commands =
     figure: /bin/sh -c "mkdir -p ./figure_test_images; python -c 'import matplotlib as mpl; print(mpl.ft2font.__file__, mpl.ft2font.__freetype_version__, mpl.ft2font.__freetype_build_type__)' > ./figure_test_images/figure_version_info.txt"

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,6 @@ extras =
 commands_pre =
     oldestdeps: minimum_dependencies dkist --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt cryptography<42 jsonschema==4.0.1
-    figure: python -c "from dkist.data.sample import download_all_sample_data; download_all_sample_data()"
     pip freeze --all --no-input
 commands =
     figure: /bin/sh -c "mkdir -p ./figure_test_images; python -c 'import matplotlib as mpl; print(mpl.ft2font.__file__, mpl.ft2font.__freetype_version__, mpl.ft2font.__freetype_build_type__)' > ./figure_test_images/figure_version_info.txt"


### PR DESCRIPTION
Adds a `TiledDataset.plot()` method which creates a quick-look plot as per the example [here](https://docs.dkist.nso.edu/projects/python-tools/en/stable/howto_guides/reproject_vbi_mosaic.html).

At the moment only plots the first image in each tile. Unsure whether to try and construct an animation like the normal dataset plotting or to pass an index argument to the plot to determine which slice is shown.

Closes #405 