### PR TITLE
`Dataset.__repr__` upgrade

### DIFF
--- a/changelog/431.trivial.rst
+++ b/changelog/431.trivial.rst
@@ -1,0 +1,1 @@
+Update Dataset representation for better readability.

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -56,7 +56,7 @@ def load_dataset(target):
     >>> from dkist.data.sample import VISP_BKPLX  # doctest: +REMOTE_DATA
     >>> print(dkist.load_dataset(VISP_BKPLX))  # doctest: +REMOTE_DATA
     This VISP Dataset BKPLX has 4 pixel and 5 world dimensions and consists of 1700 frames
-    Files are stored in /.../VISP_BKPLX
+    Files are stored in ...VISP_BKPLX
     <BLANKLINE>
     The data are represented by a <class 'dask.array.core.Array'> object:
     dask.array<reshape, shape=(4, 425, 980, 2554), dtype=float64, chunksize=(1, 1, 980, 2554), chunktype=numpy.ndarray>

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -53,7 +53,7 @@ def load_dataset(target):
 
     >>> dkist.load_dataset(Path("/path/to/ABCDE"))  # doctest: +SKIP
 
-    >>> from dkist.data.sample import VISP_BKPLX
+    >>> from dkist.data.sample import VISP_BKPLX  # doctest: +REMOTE_DATA
     >>> print(dkist.load_dataset(VISP_BKPLX))
     This VISP Dataset BKPLX has 4 pixel and 5 world dimensions and consists of 1700 frames
     Files are stored in /home/drew/.local/share/dkist/VISP_BKPLX

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -55,8 +55,10 @@ def load_dataset(target):
 
     >>> from dkist.data.sample import VISP_BKPLX  # doctest: +REMOTE_DATA
     >>> print(dkist.load_dataset(VISP_BKPLX))  # doctest: +REMOTE_DATA
-    This VISP Dataset BKPLX has 4 pixel and 5 world dimensions and consists of 1700 frames
+    This VISP Dataset BKPLX consists of 1700 frames.
     Files are stored in ...VISP_BKPLX
+    <BLANKLINE>
+    This Dataset has 4 pixel and 5 world dimensions.
     <BLANKLINE>
     The data are represented by a <class 'dask.array.core.Array'> object:
     dask.array<reshape, shape=(4, 425, 980, 2554), dtype=float64, chunksize=(1, 1, 980, 2554), chunktype=numpy.ndarray>

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -54,7 +54,7 @@ def load_dataset(target):
     >>> dkist.load_dataset(Path("/path/to/ABCDE"))  # doctest: +SKIP
 
     >>> from dkist.data.sample import VISP_BKPLX  # doctest: +REMOTE_DATA
-    >>> print(dkist.load_dataset(VISP_BKPLX))
+    >>> print(dkist.load_dataset(VISP_BKPLX))  # doctest: +REMOTE_DATA
     This VISP Dataset BKPLX has 4 pixel and 5 world dimensions and consists of 1700 frames
     Files are stored in /home/drew/.local/share/dkist/VISP_BKPLX
     <BLANKLINE>

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -45,45 +45,46 @@ def load_dataset(target):
     Examples
     --------
 
+    >>> import dkist
+
     >>> dkist.load_dataset("/path/to/VISP_L1_ABCDE.asdf")  # doctest: +SKIP
 
     >>> dkist.load_dataset("/path/to/ABCDE/")  # doctest: +SKIP
 
     >>> dkist.load_dataset(Path("/path/to/ABCDE"))  # doctest: +SKIP
 
-    >>> from sunpy.net import Fido, attrs as a
-    >>> import dkist.net
-    >>> search_results = Fido.search(a.dkist.Dataset("AGLKO"))   # doctest: +REMOTE_DATA
-    >>> files = Fido.fetch(search_results)   # doctest: +REMOTE_DATA
-    >>> dkist.load_dataset(files)   # doctest: +REMOTE_DATA
-    <dkist.dataset.dataset.Dataset object at ...>
-    This Dataset has 4 pixel and 5 world dimensions
+    >>> from dkist.data.sample import VISP_BKPLX
+    >>> print(dkist.load_dataset(VISP_BKPLX))
+    This VISP Dataset BKPLX has 4 pixel and 5 world dimensions and consists of 1700 frames
+    Files are stored in /home/drew/.local/share/dkist/VISP_BKPLX
     <BLANKLINE>
-    dask.array<reshape, shape=(4, 1000, 976, 2555), dtype=float64, chunksize=(1, 1, 976, 2555), chunktype=numpy.ndarray>
+    The data are represented by a <class 'dask.array.core.Array'> object:
+    dask.array<reshape, shape=(4, 425, 980, 2554), dtype=float64, chunksize=(1, 1, 980, 2554), chunktype=numpy.ndarray>
     <BLANKLINE>
-    Pixel Dim  Axis Name                Data size  Bounds
+    Array Dim  Axis Name                Data size  Bounds
             0  polarization state               4  None
-            1  raster scan step number       1000  None
-            2  dispersion axis                976  None
-            3  spatial along slit            2555  None
+            1  raster scan step number        425  None
+            2  dispersion axis                980  None
+            3  spatial along slit            2554  None
     <BLANKLINE>
     World Dim  Axis Name                  Physical Type                   Units
-            0  stokes                     phys.polarization.stokes        unknown
-            1  time                       time                            s
+            4  stokes                     phys.polarization.stokes        unknown
+            3  time                       time                            s
             2  helioprojective latitude   custom:pos.helioprojective.lat  arcsec
-            3  wavelength                 em.wl                           nm
-            4  helioprojective longitude  custom:pos.helioprojective.lon  arcsec
+            1  wavelength                 em.wl                           nm
+            0  helioprojective longitude  custom:pos.helioprojective.lon  arcsec
     <BLANKLINE>
     Correlation between pixel and world axes:
     <BLANKLINE>
-                   Pixel Dim
-    World Dim    0    1    2    3
-            0  yes   no   no   no
-            1   no  yes   no   no
-            2   no  yes   no  yes
-            3   no   no  yes   no
-            4   no  yes   no  yes
-
+                              |                      PIXEL DIMENSIONS
+                              |   spatial    |  dispersion  | raster scan  | polarization
+             WORLD DIMENSIONS |  along slit  |     axis     | step number  |    state
+    ------------------------- | ------------ | ------------ | ------------ | ------------
+    helioprojective longitude |      x       |              |      x       |
+                   wavelength |              |      x       |              |
+     helioprojective latitude |      x       |              |      x       |
+                         time |              |              |      x       |
+                       stokes |              |              |              |      x
     """
     known_types = _known_types_docs().keys()
     raise TypeError(f"Input type {type(target).__name__} not recognised. It must be one of {', '.join(known_types)}.")

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -56,7 +56,7 @@ def load_dataset(target):
     >>> from dkist.data.sample import VISP_BKPLX  # doctest: +REMOTE_DATA
     >>> print(dkist.load_dataset(VISP_BKPLX))  # doctest: +REMOTE_DATA
     This VISP Dataset BKPLX has 4 pixel and 5 world dimensions and consists of 1700 frames
-    Files are stored in /home/drew/.local/share/dkist/VISP_BKPLX
+    Files are stored in /.../VISP_BKPLX
     <BLANKLINE>
     The data are represented by a <class 'dask.array.core.Array'> object:
     dask.array<reshape, shape=(4, 425, 980, 2554), dtype=float64, chunksize=(1, 1, 980, 2554), chunktype=numpy.ndarray>

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -26,14 +26,15 @@ def dataset_info_str(ds):
     instr = ds.inventory.get("instrumentName", "")
     if instr:
         instr += " "
-    nframes = ds.inventory.get("frameCount", "")
+    nframes = ds.inventory.get("frameCount", "an unknown number")
+    dsID = ds.inventory.get("datasetId", "(no DatasetID)")
 
     if is_tiled:
-        s = f"This {dstype} {ds.inventory['datasetId']} consists of an array of {tile_shape} Dataset objects\n\nEach "
+        s = f"This {dstype} {dsID} consists of an array of {tile_shape} Dataset objects\n\nEach "
     else:
         s = "This "
 
-    s += f"{instr}Dataset {ds.inventory['datasetId']} has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions and consists of {nframes} frames\n"
+    s += f"{instr}Dataset {dsID} has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions and consists of {nframes} frames\n"
     if ds.files:
         s += f"Files are stored in {ds.files.basepath}\n\n"
     s += f"The data are represented by a {type(ds.data)} object:\n{ds.data}\n\n"
@@ -120,7 +121,10 @@ def _get_pp_matrix(wcs):
     header = np.vstack([[s.center(width) for s in wrapped[l]] for l, _ in enumerate(labels)]).T
 
     mstr = np.insert(mstr, 0, header, axis=0)
-    world = ["", "WORLD DIMENSIONS", *list(wcs.world_axis_names)]
+    world = ["WORLD DIMENSIONS", *list(wcs.world_axis_names)]
+    nrows = maxlines + len(wcs.world_axis_names)
+    while len(world) < nrows:
+        world.insert(0, "")
     mstr = np.insert(mstr, 0, world, axis=1)
     widths = [np.max([len(a) for a in col]) for col in mstr.T]
     mstr = np.insert(mstr, 2, ["-"*wid for wid in widths], axis=0)

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -103,7 +103,18 @@ def _get_pp_matrix(wcs):
     for i, col in enumerate(mstr.T):
         wid = np.max([len(a) for a in col])
         mstr[:, i] = np.char.rjust(col, wid)
-    print(np.array_str(mstr, max_line_width=1000))
+    return np.array_str(mstr, max_line_width=1000)
+
+
+def pp_matrix(wcs):
+    """
+    A small helper function to print a correlation matrix with labels
+
+    Parameters
+    ----------
+    wcs : `BaseHighLevelWCS` or `BaseLowLevelWCS`
+    """
+    print(_get_pp_matrix(wcs))
 
 
 def extract_pc_matrix(headers, naxes=None):

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -30,11 +30,11 @@ def dataset_info_str(ds):
     dsID = ds.inventory.get("datasetId", "(no DatasetID)")
 
     if is_tiled:
-        s = f"This {dstype} {dsID} consists of an array of {tile_shape} Dataset objects\n\nEach "
+        s = f"This {instr}{dstype} {dsID} consists of an array of {tile_shape} Dataset objects\n\nEach Dataset "
     else:
-        s = "This "
+        s = f"This {instr}Dataset {dsID} "
 
-    s += f"{instr}Dataset {dsID} has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions and consists of {nframes} frames\n"
+    s += f"has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions and consists of {nframes} frames\n"
     if ds.files:
         s += f"Files are stored in {ds.files.basepath}\n\n"
     s += f"The data are represented by a {type(ds.data)} object:\n{ds.data}\n\n"

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -26,8 +26,15 @@ def dataset_info_str(ds):
         instr += " "
     nframes = ds.inventory.get("frameCount", "")
 
-    s = f"This {instr}Dataset has {wcs.pixel_n_dim} array and {wcs.world_n_dim} world dimensions and consists of {nframes} frames stored in {ds.files.basepath}\n\n"
-    s += f"The data are represented by a Dask array: {ds.data}\n\n"
+    if is_tiled:
+        s = f"This {dstype} consists of an array of {tile_shape} Dataset objects\n\nEach "
+    else:
+        s = "This "
+
+    s += f"{instr}Dataset has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions and consists of {nframes} frames\n"
+    if ds.files:
+        s +="Files are stored in {ds.files.basepath}\n\n"
+    s += f"The data are represented by a {type(ds.data)} object:\n{ds.data}\n\n"
 
     array_shape = wcs.array_shape or (0,)
     pixel_shape = wcs.pixel_shape or (None,) * wcs.pixel_n_dim

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -19,7 +19,7 @@ def dataset_info_str(ds):
         ds = ds[0, 0]
     wcs = ds.wcs.low_level_wcs
 
-    # Pixel dimensions table
+    # Array dimensions table
 
     instr = ds.inventory.get("instrument", "")
     if instr:
@@ -47,7 +47,7 @@ def dataset_info_str(ds):
     pixel_nam_width = max(9, max(len(x) for x in pixel_axis_names))
     pixel_siz_width = max(9, len(str(max(array_shape))))
 
-    s += (("{0:" + str(pixel_dim_width) + "s}").format("Pixel Dim") + "  " +
+    s += (("{0:" + str(pixel_dim_width) + "s}").format("Array Dim") + "  " +
             ("{0:" + str(pixel_nam_width) + "s}").format("Axis Name") + "  " +
             ("{0:" + str(pixel_siz_width) + "s}").format("Data size") + "  " +
             "Bounds\n")
@@ -89,40 +89,15 @@ def dataset_info_str(ds):
 
     pixel_dim_width = max(3, len(str(wcs.world_n_dim)))
 
-    s += "Correlation between pixel and world axes:\n\n"
+    s += "Correlation between array and world axes:\n\n"
 
-    s += (" " * world_dim_width + "  " +
-            ("{0:^" + str(wcs.pixel_n_dim * 5 - 2) + "s}").format("Pixel Dim") +
-            "\n")
-
-    s += (("{0:" + str(world_dim_width) + "s}").format("World Dim") +
-            "".join(["  " + ("{0:" + str(pixel_dim_width) + "d}").format(ipix)
-                    for ipix in range(wcs.pixel_n_dim)]) +
-            "\n")
-
-    matrix = wcs.axis_correlation_matrix[::-1, ::-1]
-    matrix_str = np.empty(matrix.shape, dtype="U3")
-    matrix_str[matrix] = "yes"
-    matrix_str[~matrix] = "no"
-
-    for iwrl in range(wcs.world_n_dim):
-        s += (("{0:" + str(world_dim_width) + "d}").format(iwrl) +
-                "".join(["  " + ("{0:>" + str(pixel_dim_width) + "s}").format(matrix_str[iwrl, ipix])
-                        for ipix in range(wcs.pixel_n_dim)]) +
-                "\n")
+    s += _get_pp_matrix(ds.wcs)
 
     # Make sure we get rid of the extra whitespace at the end of some lines
     return "\n".join([line.rstrip() for line in s.splitlines()])
 
 
-def pp_matrix(wcs):
-    """
-    A small helper function to print a correlation matrix with labels
-
-    Parameters
-    ----------
-    wcs : `BaseHighLevelWCS` or `BaseLowLevelWCS`
-    """
+def _get_pp_matrix(wcs):
     slen = np.max([len(line) for line in list(wcs.world_axis_names) + list(wcs.pixel_axis_names)])
     mstr = wcs.axis_correlation_matrix.astype(f"<U{slen}")
     mstr = np.insert(mstr, 0, wcs.pixel_axis_names, axis=0)

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -109,6 +109,7 @@ def dataset_info_str(ds_in):
 
 
 def _get_pp_matrix(wcs):
+    wcs = wcs.low_level_wcs # Just in case the dataset has been sliced and returned the wrong kind of wcs
     slen = np.max([len(line) for line in list(wcs.world_axis_names) + list(wcs.pixel_axis_names)])
     mstr = wcs.axis_correlation_matrix.astype("<U")
     mstr[np.where(mstr == "True")] = "x"

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -76,11 +76,11 @@ def dataset_info_str(ds):
             ("{0:" + str(world_typ_width) + "s}").format("Physical Type") + "  " +
             "Units\n")
 
-    for iwrl in range(wcs.world_n_dim):
+    for iwrl in range(wcs.world_n_dim)[::-1]:
 
-        name = wcs.world_axis_names[::-1][iwrl] or "None"
-        typ = wcs.world_axis_physical_types[::-1][iwrl] or "None"
-        unit = wcs.world_axis_units[::-1][iwrl] or "unknown"
+        name = wcs.world_axis_names[iwrl] or "None"
+        typ = wcs.world_axis_physical_types[iwrl] or "None"
+        unit = wcs.world_axis_units[iwrl] or "unknown"
 
         s += (("{0:" + str(world_dim_width) + "d}").format(iwrl) + "  " +
                 ("{0:" + str(world_nam_width) + "s}").format(name) + "  " +

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -26,7 +26,7 @@ def dataset_info_str(ds):
     instr = ds.inventory.get("instrumentName", "")
     if instr:
         instr += " "
-    nframes = ds.inventory.get("frameCount", "an unknown number")
+    nframes = len(ds.files)
     dsID = ds.inventory.get("datasetId", "(no DatasetID)")
 
     if is_tiled:
@@ -34,8 +34,10 @@ def dataset_info_str(ds):
     else:
         s = f"This {instr}Dataset {dsID} "
 
-    s += f"has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions and consists of {nframes} frames\n"
+    s += f"has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions"
+
     if ds.files:
+        s += f" and consists of {nframes} frames\n"
         s += f"Files are stored in {ds.files.basepath}\n\n"
     s += f"The data are represented by a {type(ds.data)} object:\n{ds.data}\n\n"
 

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -39,7 +39,8 @@ def dataset_info_str(ds_in):
 
     if ds.files:
         nframes = len(ds.files) if not is_tiled else sum([len(tile.files) for tile in ds_in.flat])
-        s += f"consists of {nframes} frames stored in {ds.files.basepath}\n"
+        s += f"consists of {nframes} frames.\n"
+        s += f"Files are stored in {ds.files.basepath}\n"
 
     if is_tiled:
         s += "\nEach "

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -11,14 +11,16 @@ import gwcs
 __all__ = ["dataset_info_str"]
 
 
-def dataset_info_str(ds):
+def dataset_info_str(ds_in):
     # Check for an attribute that only appears on TiledDataset
     # Not using isinstance to avoid circular import
-    is_tiled = hasattr(ds, "combined_headers")
-    dstype = type(ds).__name__
+    is_tiled = hasattr(ds_in, "combined_headers")
+    dstype = type(ds_in).__name__
     if is_tiled:
-        tile_shape = ds.shape
-        ds = ds[0, 0]
+        tile_shape = ds_in.shape
+        ds = ds_in[0, 0]
+    else:
+        ds = ds_in
     wcs = ds.wcs.low_level_wcs
 
     # Array dimensions table
@@ -36,7 +38,8 @@ def dataset_info_str(ds):
     s += f"has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions"
 
     if ds.files:
-        s += f" and consists of {len(ds.files)} frames\n"
+        nframes = len(ds.files) if not is_tiled else sum([len(tile.files) for tile in ds_in.flat])
+        s += f" and consists of {nframes} frames\n"
         s += f"Files are stored in {ds.files.basepath}\n\n"
     s += f"The data are represented by a {type(ds.data)} object:\n{ds.data}\n\n"
 

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -30,17 +30,23 @@ def dataset_info_str(ds_in):
         instr += " "
     dsID = ds.inventory.get("datasetId", "(no DatasetID)")
 
+    s = f"This {instr}Dataset {dsID} "
     if is_tiled:
-        s = f"This {instr}{dstype} {dsID} consists of an array of {tile_shape} Dataset objects\n\nEach Dataset "
-    else:
-        s = f"This {instr}Dataset {dsID} "
+        s += f"is an array of {tile_shape} Dataset objects "
+        if ds.files:
+            s += "and \n"
 
-    s += f"has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions"
 
     if ds.files:
         nframes = len(ds.files) if not is_tiled else sum([len(tile.files) for tile in ds_in.flat])
-        s += f" and consists of {nframes} frames\n"
-        s += f"Files are stored in {ds.files.basepath}\n\n"
+        s += f"consists of {nframes} frames stored in {ds.files.basepath}\n"
+
+    if is_tiled:
+        s += "\nEach "
+    else:
+        s += "\nThis "
+    s += f"Dataset has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions.\n\n"
+
     s += f"The data are represented by a {type(ds.data)} object:\n{ds.data}\n\n"
 
     array_shape = wcs.array_shape or (0,)

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -21,16 +21,13 @@ def dataset_info_str(ds):
 
     # Array dimensions table
 
-    instr = ds.inventory.get("instrument", "")
+    instr = ds.inventory.get("instrumentName", "")
     if instr:
         instr += " "
+    nframes = ds.inventory.get("frameCount", "")
 
-    if is_tiled:
-        s = f"This {dstype} consists of an array of {tile_shape} Dataset objects\n\n"
-        s += f"Each {instr}Dataset has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions\n\n"
-    else:
-        s = f"This {instr}Dataset has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions\n\n"
-    s += f"{ds.data}\n\n"
+    s = f"This {instr}Dataset has {wcs.pixel_n_dim} array and {wcs.world_n_dim} world dimensions and consists of {nframes} frames stored in {ds.files.basepath}\n\n"
+    s += f"The data are represented by a Dask array: {ds.data}\n\n"
 
     array_shape = wcs.array_shape or (0,)
     pixel_shape = wcs.pixel_shape or (None,) * wcs.pixel_n_dim

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -26,7 +26,6 @@ def dataset_info_str(ds):
     instr = ds.inventory.get("instrumentName", "")
     if instr:
         instr += " "
-    nframes = len(ds.files)
     dsID = ds.inventory.get("datasetId", "(no DatasetID)")
 
     if is_tiled:
@@ -37,7 +36,7 @@ def dataset_info_str(ds):
     s += f"has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions"
 
     if ds.files:
-        s += f" and consists of {nframes} frames\n"
+        s += f" and consists of {len(ds.files)} frames\n"
         s += f"Files are stored in {ds.files.basepath}\n\n"
     s += f"The data are represented by a {type(ds.data)} object:\n{ds.data}\n\n"
 

--- a/dkist/dataset/utils.py
+++ b/dkist/dataset/utils.py
@@ -29,13 +29,13 @@ def dataset_info_str(ds):
     nframes = ds.inventory.get("frameCount", "")
 
     if is_tiled:
-        s = f"This {dstype} consists of an array of {tile_shape} Dataset objects\n\nEach "
+        s = f"This {dstype} {ds.inventory['datasetId']} consists of an array of {tile_shape} Dataset objects\n\nEach "
     else:
         s = "This "
 
-    s += f"{instr}Dataset has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions and consists of {nframes} frames\n"
+    s += f"{instr}Dataset {ds.inventory['datasetId']} has {wcs.pixel_n_dim} pixel and {wcs.world_n_dim} world dimensions and consists of {nframes} frames\n"
     if ds.files:
-        s +="Files are stored in {ds.files.basepath}\n\n"
+        s += f"Files are stored in {ds.files.basepath}\n\n"
     s += f"The data are represented by a {type(ds.data)} object:\n{ds.data}\n\n"
 
     array_shape = wcs.array_shape or (0,)

--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -29,7 +29,7 @@ Here is a really quick demo of searching for all unembargoed VISP data and downl
     >>> from sunpy.net import Fido, attrs as a
     >>> import dkist.net
 
-    >>> res = Fido.search(a.Instrument.visp, a.dkist.Embargoed.false)  # doctest: +REMOTE_DATA
+    >>> res = Fido.search(a.Instrument.visp, a.dkist.Embargoed.false)  # doctest: +SKIP
     >>> res  # doctest: +SKIP
     <sunpy.net.fido_factory.UnifiedResponse object at ...>
     Results from 1 Provider:
@@ -44,8 +44,8 @@ Here is a really quick demo of searching for all unembargoed VISP data and downl
     <BLANKLINE>
     <BLANKLINE>
 
-    >>> asdf_files = Fido.fetch(res[:, 0])  # doctest: +REMOTE_DATA
-    >>> asdf_files  # doctest: +REMOTE_DATA
+    >>> asdf_files = Fido.fetch(res[:, 0])  # doctest: +SKIP
+    >>> asdf_files  # doctest: +SKIP
     <parfive.results.Results object at ...>
     ['...VISP_L1_20220602T175042_BDWQK.asdf']
 
@@ -133,8 +133,8 @@ This means you can first slice out a smaller dataset, and then only download the
 
 .. code-block:: python
 
-    >>> stokes_I_ds = ds[0]  # doctest: +REMOTE_DATA
-    >>> stokes_I_ds  # doctest: +REMOTE_DATA
+    >>> stokes_I_ds = ds[0]  # doctest: +SKIP
+    >>> stokes_I_ds  # doctest: +SKIP
     <dkist.dataset.dataset.Dataset object at ...>
     This Dataset has 3 pixel and 4 world dimensions
     <BLANKLINE>

--- a/docs/whatsnew/1.0.rst
+++ b/docs/whatsnew/1.0.rst
@@ -60,8 +60,8 @@ Any DKIST level one ASDF file can be loaded with the `dkist.load_dataset` functi
 
     >>> import dkist
 
-    >>> ds = dkist.load_dataset(asdf_files)  # doctest: +REMOTE_DATA
-    >>> ds  # doctest: +REMOTE_DATA
+    >>> ds = dkist.load_dataset(asdf_files)  # doctest: +SKIP
+    >>> ds  # doctest: +SKIP
     <dkist.dataset.dataset.Dataset object at ...>
     This Dataset has 4 pixel and 5 world dimensions
     <BLANKLINE>


### PR DESCRIPTION
Some updates to make the dataset representation a bit more user friendly and informative. Includes changes to `TiledDataset.__repr__` from #402 so that should probably be merged first. 

Output for the sample VISP and VBI datasets:

```
This VISP Dataset has 4 pixel and 5 world dimensions and consists of 1700 frames
Files are stored in {ds.files.basepath}

The data are represented by a <class 'dask.array.core.Array'> object:
dask.array<reshape, shape=(4, 425, 980, 2554), dtype=float64, chunksize=(1, 1, 980, 2554), chunktype=numpy.ndarray>

Array Dim  Axis Name                Data size  Bounds
        0  polarization state               4  None
        1  raster scan step number        425  None
        2  dispersion axis                980  None
        3  spatial along slit            2554  None

World Dim  Axis Name                  Physical Type                   Units
        4  stokes                     phys.polarization.stokes        unknown
        3  time                       time                            s
        2  helioprojective latitude   custom:pos.helioprojective.lat  arcsec
        1  wavelength                 em.wl                           nm
        0  helioprojective longitude  custom:pos.helioprojective.lon  arcsec

Correlation between array and world axes:

                          |                      PIXEL DIMENSIONS
                          |   spatial    |  dispersion  | raster scan  | polarization
         WORLD DIMENSIONS |  along slit  |     axis     | step number  |    state
------------------------- | ------------ | ------------ | ------------ | ------------
helioprojective longitude |      x       |              |      x       |
               wavelength |              |      x       |              |
 helioprojective latitude |      x       |              |      x       |
                     time |              |              |      x       |
                   stokes |              |              |              |      x

-----

This TiledDataset consists of an array of (3, 3) Dataset objects

Each VBI Dataset has 3 pixel and 3 world dimensions and consists of 27 frames
Files are stored in {ds.files.basepath}

The data are represented by a <class 'dask.array.core.Array'> object:
dask.array<reshape, shape=(3, 4096, 4096), dtype=float32, chunksize=(1, 4096, 4096), chunktype=numpy.ndarray>

Array Dim  Axis Name                  Data size  Bounds
        0  time                               3  None
        1  helioprojective latitude        4096  None
        2  helioprojective longitude       4096  None

World Dim  Axis Name                  Physical Type                   Units
        2  time                       time                            s
        1  helioprojective latitude   custom:pos.helioprojective.lat  arcsec
        0  helioprojective longitude  custom:pos.helioprojective.lon  arcsec

Correlation between array and world axes:

                          |                   PIXEL DIMENSIONS
                          | helioprojective | helioprojective |       time
         WORLD DIMENSIONS |    longitude    |     latitude    |
------------------------- | --------------- | --------------- | ---------------
helioprojective longitude |        x        |        x        |        x
 helioprojective latitude |        x        |        x        |        x
                     time |                 |                 |        x
```