### PR TITLE
Fix FileManager slicing

### DIFF
--- a/changelog/453.bugfix.rst
+++ b/changelog/453.bugfix.rst
@@ -1,0 +1,1 @@
+Minor tweak to correct indexing of >4D datasets.

--- a/dkist/conftest.py
+++ b/dkist/conftest.py
@@ -350,6 +350,18 @@ def visp_dataset_no_headers(tmp_path_factory):
     return load_dataset(vispdir / "test_visp_no_headers.asdf")
 
 
+@pytest.fixture
+def large_visp_no_dummy_axis(large_visp_dataset):
+    # Slightly tweaked dataset to remove the dummy axis in the file manager array shape.
+    large_visp_dataset._file_manager = FileManager.from_parts([f"dummyfile_{i}" for i in range(4*20)],
+                                                              0,
+                                                              float,
+                                                              (50, 128),
+                                                              loader=AstropyFITSLoader, basepath="./")
+
+    return large_visp_dataset
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
     try:

--- a/dkist/conftest.py
+++ b/dkist/conftest.py
@@ -353,11 +353,9 @@ def visp_dataset_no_headers(tmp_path_factory):
 @pytest.fixture
 def large_visp_no_dummy_axis(large_visp_dataset):
     # Slightly tweaked dataset to remove the dummy axis in the file manager array shape.
-    large_visp_dataset._file_manager = FileManager.from_parts([f"dummyfile_{i}" for i in range(4*20)],
-                                                              0,
-                                                              float,
-                                                              (50, 128),
-                                                              loader=AstropyFITSLoader, basepath="./")
+    shape = large_visp_dataset.data.shape[:2]
+    fileuris = np.array([f"dummyfile_{i}" for i in range(np.prod(shape))]).reshape(shape)
+    large_visp_dataset._file_manager = FileManager.from_parts(fileuris, 0, float, (50, 128), loader=AstropyFITSLoader, basepath="./")
 
     return large_visp_dataset
 

--- a/dkist/conftest.py
+++ b/dkist/conftest.py
@@ -268,6 +268,31 @@ def dataset_4d(identity_gwcs_4d, empty_meta):
 
 
 @pytest.fixture
+def dataset_5d(identity_gwcs_5d_stokes, empty_meta):
+    shape = (4, 40, 30, 20, 10)
+    x = np.ones(shape)
+    array = da.from_array(x, tuple(shape))
+
+    identity_gwcs_4d.pixel_shape = array.shape[::-1]
+    identity_gwcs_4d.array_shape = array.shape
+
+    ds = Dataset(array, wcs=identity_gwcs_5d_stokes, meta={"inventory": {}, "headers": Table()}, unit=u.count)
+    fileuris = np.array([f"dummyfile_{i}" for i in range(np.prod(shape[:-2]))]).reshape(shape[:-2])
+    ds._file_manager = FileManager.from_parts(fileuris, 0, float, shape[-2:], loader=AstropyFITSLoader, basepath="./")
+
+    return ds
+
+
+@pytest.fixture
+def dataset_5d_dummy_filemanager_axis(dataset_5d):
+    shape = dataset_5d.data.shape
+    fileuris = np.array([f"dummyfile_{i}" for i in range(np.prod(shape[:-2]))]).reshape(shape[:-2])
+    dataset_5d._file_manager = FileManager.from_parts(fileuris, 0, float, (1, *shape[-2:]), loader=AstropyFITSLoader, basepath="./")
+
+    return dataset_5d
+
+
+@pytest.fixture
 def eit_dataset():
     eitdir = Path(rootdir) / "EIT"
     with asdf.open(eitdir / "eit_test_dataset.asdf") as f:

--- a/dkist/dataset/tests/test_dataset.py
+++ b/dkist/dataset/tests/test_dataset.py
@@ -180,9 +180,11 @@ def test_header_slicing_3D_slice(large_visp_dataset):
 
 @pytest.mark.accept_cli_dataset
 def test_file_slicing_with_dummy_axis(large_visp_dataset):
+    assert len(large_visp_dataset[0].files) == 20
     assert len(large_visp_dataset[0, 0].files) == 1
 
 
 @pytest.mark.accept_cli_dataset
 def test_file_slicing_without_dummy_axis(large_visp_no_dummy_axis):
+    assert len(large_visp_no_dummy_axis[0].files) == 20
     assert len(large_visp_no_dummy_axis[0, 0].files) == 1

--- a/dkist/dataset/tests/test_dataset.py
+++ b/dkist/dataset/tests/test_dataset.py
@@ -176,3 +176,13 @@ def test_header_slicing_3D_slice(large_visp_dataset):
 
     assert len(sliced.files.filenames) == len(sliced_headers["FILENAME"]) == len(sliced.headers)
     assert (sliced.headers["DINDEX3", "DINDEX4"] == sliced_headers["DINDEX3", "DINDEX4"]).all()
+
+
+@pytest.mark.accept_cli_dataset
+def test_file_slicing_with_dummy_axis(large_visp_dataset):
+    assert len(large_visp_dataset[0, 0].files) == 1
+
+
+@pytest.mark.accept_cli_dataset
+def test_file_slicing_without_dummy_axis(large_visp_no_dummy_axis):
+    assert len(large_visp_no_dummy_axis[0, 0].files) == 1

--- a/dkist/dataset/tests/test_dataset.py
+++ b/dkist/dataset/tests/test_dataset.py
@@ -179,12 +179,22 @@ def test_header_slicing_3D_slice(large_visp_dataset):
 
 
 @pytest.mark.accept_cli_dataset
-def test_file_slicing_with_dummy_axis(large_visp_dataset):
-    assert len(large_visp_dataset[0].files) == 20
-    assert len(large_visp_dataset[0, 0].files) == 1
+def test_file_slicing_with_dummy_axis(dataset_5d_dummy_filemanager_axis):
+    ds = dataset_5d_dummy_filemanager_axis
+    shape = ds.data.shape
+    assert len(ds.files) == np.prod(shape[:3])
+    assert len(ds[0].files) == np.prod(shape[1:3])
+    assert len(ds[0, 0].files) == np.prod(shape[2])
+    assert len(ds[0, 0, 0].files) == 1
+    assert len(ds[0, 0, 0, 0].files) == 1
 
 
 @pytest.mark.accept_cli_dataset
-def test_file_slicing_without_dummy_axis(large_visp_no_dummy_axis):
-    assert len(large_visp_no_dummy_axis[0].files) == 20
-    assert len(large_visp_no_dummy_axis[0, 0].files) == 1
+def test_file_slicing_without_dummy_axis(dataset_5d):
+    ds = dataset_5d
+    shape = ds.data.shape
+    assert len(ds.files) == np.prod(shape[:3])
+    assert len(ds[0].files) == np.prod(shape[1:3])
+    assert len(ds[0, 0].files) == np.prod(shape[2])
+    assert len(ds[0, 0, 0].files) == 1
+    assert len(ds[0, 0, 0, 0].files) == 1

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -242,7 +242,7 @@ class BaseFileManager:
         aslice = list(sanitize_slices(aslice, len(self.output_shape)))
         if fits_array_shape[0] == 1:
             # Insert a blank slice for the dummy dimension
-            aslice.insert(len(fits_array_shape) - 1, slice(None))
+            aslice.insert(len(fits_array_shape), slice(None))
         # Now only use the dimensions of the slice not covered by the array axes
         aslice = aslice[:-1*len(fits_array_shape)]
         return tuple(aslice)

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -242,7 +242,7 @@ class BaseFileManager:
         aslice = list(sanitize_slices(aslice, len(self.output_shape)))
         if fits_array_shape[0] == 1:
             # Insert a blank slice for the dummy dimension
-            aslice.insert(len(fits_array_shape), slice(None))
+            aslice.insert(-(len(fits_array_shape)-1), slice(None))
         # Now only use the dimensions of the slice not covered by the array axes
         aslice = aslice[:-1*len(fits_array_shape)]
         return tuple(aslice)


### PR DESCRIPTION
Fixes #449.

Seems the issue was that the blank slice was being inserted too early in the list. This addresses that but I'm not sure yet what else it will impact.