### PR TITLE
Speed up distributed Dask by removing reference to array_container in FITSLoader

### DIFF
--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -97,14 +97,13 @@ class StripedExternalArray(BaseStripedExternalArray):
         self.dtype = dtype
         self.target = target
         self._loader = loader
-        self._basepath = None
-        self.basepath = basepath  # Use the setter to convert to a Path
+        self._basepath = self._sanitize_basepath(basepath)
         self.chunksize = chunksize
         self._fileuri_array = np.atleast_1d(np.array(fileuris))
 
         loader_array = np.empty_like(self._fileuri_array, dtype=object)
         for i, fileuri in enumerate(self._fileuri_array.flat):
-            loader_array.flat[i] = loader(fileuri, shape, dtype, target, self)
+            loader_array.flat[i] = loader(fileuri, shape, dtype, target, self.basepath)
 
         self._loader_array = loader_array
 
@@ -125,13 +124,15 @@ class StripedExternalArray(BaseStripedExternalArray):
         """
         return self._basepath
 
+    @staticmethod
+    def _sanitize_basepath(value):
+        return Path(value).expanduser() if value is not None else None
+
     @basepath.setter
     def basepath(self, value: os.PathLike | str | None):
-        self._basepath = Path(value).expanduser() if value is not None else None
-        if hasattr(self, '_loader_array'):
-            # We get called during __init__ before _loader_array is created
-            for loader in self._loader_array.flat:
-                loader.basepath = self._basepath
+        self._basepath = self._sanitize_basepath(value)
+        for loader in self._loader_array.flat:
+            loader.basepath = self._basepath
 
     @property
     def fileuri_array(self) -> NDArray[str]:

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -128,6 +128,10 @@ class StripedExternalArray(BaseStripedExternalArray):
     @basepath.setter
     def basepath(self, value: os.PathLike | str | None):
         self._basepath = Path(value).expanduser() if value is not None else None
+        if hasattr(self, '_loader_array'):
+            # We get called during __init__ before _loader_array is created
+            for loader in self._loader_array.flat:
+                loader.basepath = self._basepath
 
     @property
     def fileuri_array(self) -> NDArray[str]:

--- a/dkist/io/loaders.py
+++ b/dkist/io/loaders.py
@@ -50,7 +50,7 @@ class BaseFITSLoader(metaclass=abc.ABCMeta):
         self.shape = shape
         self.dtype = dtype
         self.target = target
-        self.array_container = array_container
+        self.basepath = array_container.basepath
         self.ndim = len(self.shape)
         self.size = np.prod(self.shape)
 
@@ -67,10 +67,6 @@ class BaseFITSLoader(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def __getitem__(self, slc):
         pass
-
-    @property
-    def basepath(self):
-        return self.array_container.basepath
 
     @property
     def absolute_uri(self):

--- a/dkist/io/loaders.py
+++ b/dkist/io/loaders.py
@@ -45,12 +45,12 @@ class BaseFITSLoader(metaclass=abc.ABCMeta):
     time.
     """
 
-    def __init__(self, fileuri, shape, dtype, target, array_container):
+    def __init__(self, fileuri, shape, dtype, target, basepath):
         self.fileuri = fileuri
         self.shape = shape
         self.dtype = dtype
         self.target = target
-        self.basepath = array_container.basepath
+        self.basepath = basepath
         self.ndim = len(self.shape)
         self.size = np.prod(self.shape)
 


### PR DESCRIPTION
I've been finding that the Dask arrays generated by this package don't give me the speed I would hope for, and this PR helps address that. (I'm working on another, too.)

My use case right now (my first with DKIST) is taking a ViSP data set and summing over wavelength to get a quasi-broadband view of what ViSP was seeing.

Doing this serially takes 1 m 53 s
```python
ds = dkist.load_dataset("/home/svankooten/BXXDZ/")

def comp_slice(file):
    data = fits.getdata("/home/svankooten/BXXDZ/" + file)
    data = data[0]
    return data.sum(axis=0)

image = np.stack(list(map(comp_slice, ds.files.filenames)))
```

Doing this with multiprocessing takes 16 s with 8 cores
```python
from multiprocessing import Pool

with Pool(8) as p:
    image = np.stack(p.map(comp_slice, ds.files.filenames))
```

The default dask scheduler uses threads, and with the GIL I get 250-300% CPU usage and it takes 1m 5s
```python
ds.data.sum(axis=-2).compute();
```

Switching to Dask's distributed scheduler evades the GIL and ideally will look like the multiprocessing case, but it actually takes longer than the serial case, at 2m 33s
```python
from dask.distributed import Client
client = Client(threads_per_worker=1, n_workers=8)
ds.data.sum(axis=-2).compute()
```

The task stream in the scheduler shows that there are lots of gaps between tasks
![image](https://github.com/user-attachments/assets/4bef682f-b035-46f5-bb40-8ab85430b0cc)

What I finally found as the cause is that each `AstropyFITSLoader` keeps a reference to its parent `StripedExternalArray`. As I understand it, the loaders get pickled and sent to the worker processes before they're used, and this reference causes these pickle payloads to be several megabytes each. This PR avoids pickling the `StripedExternalArray`. This makes the task stream much denser, and lets the computation complete in 47 s
![image](https://github.com/user-attachments/assets/02f91207-e0cd-4b82-b9c5-eb364722e610)
(The x scale is different in this screenshot)

This beats the serial case (!) and the default threaded scheduler, but doesn't match multiprocessing. (Not sure how close this can get, I assume Dask has more overhead.) This PR doesn't change the run time for the default scheduler, which I suppose doesn't need to do any pickling.

This PR has the `Loaders` just record the `basepath` when they're created. If `Filemanager.basepath` is updated later on, the setter in `StripedExternalArray` now iterates through `loader_array` and updates each one. This has the downside of no longer having a single source of truth for `basepath`, but I think it's worth the speedup. (And it seems like a user would have to dig deep in internal API to change one but not the others.)

An alternate design I tried was to have have `BaseFITSLoader` keep its `array_container` reference, but I overrode `BaseFITSLoader`'s pickling behavior so that only `array_container.basepath` is sent, not `array_container` itself. Then the unpickled loaders in the worker processes set a `_basepath` value (a snapshot of the "live" value at the time of pickling, which is when the dask calculation is triggered) but don't set `array_container`, and the `basepath` property returns whichever is set. This lets `basepath` be stored in only one location in the main process, but I think it has the side-effect that if a user loads a dataset, pickles it for some reason, unpickles it, updates the basepath and then triggers the Dask calculation, the pickling will have caused the loaders to drop their references and they won't get the updated basepath.

Hopefully this PR doesn't conflict with any future plans for `FITSLoader`!