### PR TITLE
Making the array

### DIFF
--- a/dkist/io/dask_utils.py
+++ b/dkist/io/dask_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 __all__ = ["stack_loader_array"]
 
 
-def stack_loader_array(loader_array, chunksize=None, batch_size=1):
+def stack_loader_array(loader_array, output_shape, chunksize=None, batch_size=1):
     """
     Stack a loader array along each of its dimensions.
 
@@ -35,11 +35,11 @@ def stack_loader_array(loader_array, chunksize=None, batch_size=1):
                              name="load_files",
                              chunks=chunks,
                              dtype=loader_array.flat[0].dtype)
+    array = array.reshape(output_shape)
     if chunksize is not None:
         # If requested, re-chunk the array. Not sure this is optimal
         new_chunks = (1,) * (array.ndim - len(chunksize)) + chunksize
         array = array.rechunk(new_chunks)
-    # The calling function reshapes the array to the final, correct shape
     return array
 
 

--- a/dkist/io/dask_utils.py
+++ b/dkist/io/dask_utils.py
@@ -20,8 +20,6 @@ def stack_loader_array(loader_array, chunksize=None, batch_size=1):
     -------
     array : `dask.array.Array`
     """
-    # If the chunksize isn't specified then use the whole array shape
-    chunksize = chunksize or loader_array.flat[0].shape
     file_shape = loader_array.flat[0].shape
 
     tasks = {}
@@ -37,6 +35,11 @@ def stack_loader_array(loader_array, chunksize=None, batch_size=1):
                              name="load_files",
                              chunks=chunks,
                              dtype=loader_array.flat[0].dtype)
+    if chunksize is not None:
+        # If requested, re-chunk the array. Not sure this is optimal
+        new_chunks = (1,) * (array.ndim - len(chunksize)) + chunksize
+        array = array.rechunk(new_chunks)
+    # The calling function reshapes the array to the final, correct shape
     return array
 
 

--- a/dkist/io/dask_utils.py
+++ b/dkist/io/dask_utils.py
@@ -8,13 +8,20 @@ __all__ = ["stack_loader_array"]
 
 def stack_loader_array(loader_array, output_shape, chunksize=None, batch_size=1):
     """
-    Stack a loader array along each of its dimensions.
+    Converts an array of loaders to a dask array that loads a chunk from each loader
 
     This results in a dask array with the correct chunks and dimensions.
 
     Parameters
     ----------
-    loader_array : `dkist.io.reference_collections.BaseFITSArrayContainer`
+    loader_array : `dkist.io.loaders.BaseFITSLoader`
+        An array of loader objects
+    output_shape : tuple[int]
+        The intended shape of the final array
+    chunksize : tuple[int]
+        Can be used to set a chunk size. If not provided, each batch is one chunk
+    batch_size : int
+        The number of files to load in each dask task
 
     Returns
     -------

--- a/dkist/io/dask_utils.py
+++ b/dkist/io/dask_utils.py
@@ -1,12 +1,12 @@
-from functools import partial
+from itertools import batched
 
-import dask.array as da
+import dask
 import numpy as np
 
 __all__ = ["stack_loader_array"]
 
 
-def stack_loader_array(loader_array, chunksize):
+def stack_loader_array(loader_array, chunksize=None, batch_size=1):
     """
     Stack a loader array along each of its dimensions.
 
@@ -22,39 +22,26 @@ def stack_loader_array(loader_array, chunksize):
     """
     # If the chunksize isn't specified then use the whole array shape
     chunksize = chunksize or loader_array.flat[0].shape
+    file_shape = loader_array.flat[0].shape
 
-    if loader_array.size == 1:
-        return tuple(loader_to_dask(loader_array, chunksize))[0]
-    if len(loader_array.shape) == 1:
-        return da.stack(loader_to_dask(loader_array, chunksize))
-    stacks = []
-    for i in range(loader_array.shape[0]):
-        stacks.append(stack_loader_array(loader_array[i], chunksize))
-    return da.stack(stacks)
+    tasks = {}
+    batches = list(batched(loader_array.flat, batch_size))
+    for i, loaders in enumerate(batches):
+        key = ("load_files", i)
+        key += (0,) * len(file_shape)
+        tasks[key] = (_load_batch, loaders)
+
+    dsk = dask.highlevelgraph.HighLevelGraph.from_collections("load_files", tasks, dependencies=())
+    chunks = (tuple(len(b) for b in batches),) + tuple((s,) for s in file_shape)
+    array = dask.array.Array(dsk,
+                             name="load_files",
+                             chunks=chunks,
+                             dtype=loader_array.flat[0].dtype)
+    return array
 
 
-def _partial_to_array(loader, *, meta, chunks):
-    # Set the name of the array to the filename, that should be unique within the array
-    return da.from_array(loader, meta=meta, chunks=chunks, name=loader.fileuri)
-
-
-def loader_to_dask(loader_array, chunksize):
-    """
-    Map a call to `dask.array.from_array` onto all the elements in ``loader_array``.
-
-    This is done so that an explicit ``meta=`` argument can be provided to
-    prevent loading data from disk.
-    """
-    if loader_array.size != 1 and len(loader_array.shape) != 1:
-        raise ValueError("Can only be used on one dimensional arrays")
-
-    loader_array = np.atleast_1d(loader_array)
-
-    # The meta argument to from array is used to determine properties of the
-    # array, such as dtype. We explicitly specify it here to prevent dask
-    # trying to auto calculate it by reading from the actual array on disk.
-    meta = np.zeros((0,), dtype=loader_array[0].dtype)
-
-    to_array = partial(_partial_to_array, meta=meta, chunks=chunksize)
-
-    return map(to_array, loader_array)
+def _load_batch(loaders):
+    arrays = [loader.data for loader in loaders]
+    if len(arrays) == 1:
+        return arrays[0]
+    return np.concatenate(arrays)

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -77,7 +77,7 @@ class BaseStripedExternalArray:
         still have a reference to this `~.FileManager` object, meaning changes
         to this object will be reflected in the data loaded by the array.
         """
-        return stack_loader_array(self.loader_array, self.chunksize).reshape(self.output_shape)
+        return stack_loader_array(self.loader_array, self.output_shape, self.chunksize)
 
 
 class StripedExternalArray(BaseStripedExternalArray):

--- a/dkist/io/loaders.py
+++ b/dkist/io/loaders.py
@@ -64,6 +64,10 @@ class BaseFITSLoader(metaclass=abc.ABCMeta):
     def data(self):
         return self[:]
 
+    def __call__(self):
+        # Support inserting loader directly into a Dask task
+        return self[:]
+
     @abc.abstractmethod
     def __getitem__(self, slc):
         pass

--- a/dkist/io/loaders.py
+++ b/dkist/io/loaders.py
@@ -64,10 +64,6 @@ class BaseFITSLoader(metaclass=abc.ABCMeta):
     def data(self):
         return self[:]
 
-    def __call__(self):
-        # Support inserting loader directly into a Dask task
-        return self[:]
-
     @abc.abstractmethod
     def __getitem__(self, slc):
         pass


### PR DESCRIPTION
I'm unsure if this PR is worth it, but it offers some extra analysis on the optimization/chunk size front.

This PR speeds up computation with the distributed scheduler a bit by changing the code for building the Dask array to simplify the task graph (or so I believe). Instead of several iterations of `da.stack` calls, it directly generates Dask tasks for each chunk of the final array, following the [example here](https://docs.dask.org/en/latest/array-design.html). This shaves a bit of time off when using the distributed scheduler (36 to 32 seconds), but the "processes" scheduler is still faster and is almost unaffected by this change (from a consistent 20.5 to 19.7 seconds). I'm using the same test case as in #455 .

This PR currently needs more thought on handling non-default chunksizes (the argument to `stack_loader_array`, which it looks like can be set in the ASDF file?). I guess I'm not sure what the intended use case is for that. In `main` it looks like this option can only sub-divide files into smaller chunks. Are there DKIST files out there that are too big to be a single chunk? Or is the idea to subdivide files when only a portion of each file has to be loaded? As this PR is now, each file gets fully loaded, and then split up, which might be less efficient. But before this PR, I'm not sure if that was also the case, or if `hdu.data[slice]` loads just the sliced portion of the file. If the latter, changing this PR to make use of that would, I think, require manually creating tasks for each chunk of each file, which seems complicated.

In #455, there was discussion of rechunking to larger chunk sizes. At least for that test case, using `.rechunk((1, 100, -1, -1))` actually slows down the total computation (I'm seeing it go from 36 to 45 seconds), I assume from the overhead of gathering and combining arrays. This PR's design makes it easy to try larger chunk sizes more efficiently, as one "loading" task can load multiple files and concatenate them immediately, rather than adding a separate layer to the task graph. This is implemented in this PR, in the `Docstring` commit and before. A "batch size" can be set, and each Dask task loads that many files and concatenates them. (The batch size has to be adjusted in the code---I didn't know how to expose it as an option for `load_dataset`.) I found that with a batch size of 100 (producing chunks of a few hundred MB, Dask's recommended size), I was actually getting a very slightly longer runtime (going from 24 to 27 seconds), but it's less extreme than using `.rechunk()`. My guess is that the `np.concatenate` call copying all the data arrays offsets any efficiency gains from the larger chunks. (Maybe if I were doing a lot more with the data it would be worth it.) I didn't see a way to have Astropy FITS load a file directly into a view of a larger output array, unfortunately.

Here's the task stream (top is before, bottom is this PR):
![image](https://github.com/user-attachments/assets/30085b54-e687-4b98-8d61-ee8847482a7f)

And here's a portion of the task graph for each (left is before, right is this PR). This is from `dataset.data.visualize()`, and I made an asdf file with only a handful of FITS files so the images wouldn't be unrenderably large.
![image](https://github.com/user-attachments/assets/af017922-72bd-4772-b92a-78de6a9d9f0d)

Right now my thinking is "just use the `processes` scheduler", where the gains from this PR are small enough that I'm not sure it's worth more work to handle the `chunksize` argument better.