### PR TITLE
Add inventory refresh to download

### DIFF
--- a/changelog/539.bugfix.rst
+++ b/changelog/539.bugfix.rst
@@ -1,0 +1,1 @@
+Dataset inventory is now refreshed before downloading FITS files with globus to ensure that any data which has been moved at the data center is still downloaded correctly.

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -15,6 +15,7 @@ view into the original ``StripedExternalArray`` object through the
 ``StripedExternalArrayView`` class.
 """
 import os
+import json
 import urllib
 from typing import Any
 from pathlib import Path
@@ -332,7 +333,7 @@ class FileManager(BaseFileManager):
         from dkist.net import conf
 
         parsed = list(urllib.parse.urlparse(conf.dataset_endpoint))
-        parsed[2] = conf.dataset_search_path
+        parsed[2] = parsed[2] + conf.dataset_search_path
         parsed[4] = urllib.parse.urlencode({"datasetIds": datasetID})
         full_url = urllib.parse.urlunparse(parsed)
 
@@ -357,7 +358,7 @@ class FileManager(BaseFileManager):
             raise ValueError(
                 "This file manager has no associated Dataset object, "
                 "so the data can not be downloaded."
-            )
+            )  # pragma: no cover
         return self._ndcube.meta["inventory"]["datasetId"]
 
     @property

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -329,15 +329,15 @@ class FileManager(BaseFileManager):
         return conf.download_endpoint
 
     @staticmethod
-    def _get_inventory(datasetID):
+    def _get_inventory(dataset_id):
         from dkist.net import conf
 
         parsed = list(urllib.parse.urlparse(conf.dataset_endpoint))
         parsed[2] = parsed[2] + conf.dataset_search_path
-        parsed[4] = urllib.parse.urlencode({"datasetIds": datasetID})
+        parsed[4] = urllib.parse.urlencode({"datasetIds": dataset_id})
         full_url = urllib.parse.urlunparse(parsed)
 
-        log.info("Refreshing dataset inventory for dataset %s", datasetID)
+        log.info("Refreshing dataset inventory for dataset %s", dataset_id)
         try:
             resp = urllib.request.urlopen(full_url, timeout=1)
         except urllib.error.HTTPError as e:

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -15,6 +15,7 @@ view into the original ``StripedExternalArray`` object through the
 ``StripedExternalArrayView`` class.
 """
 import os
+import urllib
 from typing import Any
 from pathlib import Path
 from collections.abc import Iterable
@@ -30,6 +31,7 @@ except ImportError:
 
 from astropy.wcs.wcsapi.wrappers.sliced_wcs import sanitize_slices
 
+from dkist import log
 from dkist.io.dask_utils import stack_loader_array
 from dkist.io.loaders import BaseFITSLoader
 from dkist.utils.inventory import humanize_inventory, path_format_inventory
@@ -309,13 +311,14 @@ class FileManager(BaseFileManager):
     retrieving these FITS files, as well as specifying where to load these
     files from.
     """
-    __slots__ = ["_ndcube"]
+    __slots__ = ["_inventory_cache", "_ndcube"]
 
     def __init__(self, fits_loader: StripedExternalArray):
         super().__init__(fits_loader)
         # When this object is attached to a Dataset object this attribute will
         # be populated with a reference to that Dataset instance.
         self._ndcube = None
+        self._inventory_cache = None
 
     @property
     def _metadata_streamer_url(self):
@@ -324,7 +327,52 @@ class FileManager(BaseFileManager):
 
         return conf.download_endpoint
 
-    def quality_report(self, path=None, overwrite=None):
+    @staticmethod
+    def _get_inventory(datasetID):
+        from dkist.net import conf
+
+        parsed = list(urllib.parse.urlparse(conf.dataset_endpoint))
+        parsed[2] = conf.dataset_search_path
+        parsed[4] = urllib.parse.urlencode({"datasetIds": datasetID})
+        full_url = urllib.parse.urlunparse(parsed)
+
+        log.info("Refreshing dataset inventory for dataset %s", datasetID)
+        try:
+            resp = urllib.request.urlopen(full_url, timeout=1)
+        except urllib.error.HTTPError as e:
+            log.error("Inventory refresh failed with %s", e)
+            return
+        if resp.code != 200:
+            log.error("Inventory refresh failed with error code %s", resp.code)
+            return
+
+        jresp = json.loads(resp.read())
+        results = jresp["searchResults"]
+        if len(results) == 1:
+            return results[0]
+
+    @property
+    def _dataset_id(self):
+        if self._ndcube is None:
+            raise ValueError(
+                "This file manager has no associated Dataset object, "
+                "so the data can not be downloaded."
+            )
+        return self._ndcube.meta["inventory"]["datasetId"]
+
+    @property
+    def _inventory(self):
+        if self._inventory_cache is not None:
+            return self._inventory_cache
+
+        new_inv = self._get_inventory(self._dataset_id)
+        if new_inv is not None:
+            self._inventory_cache = new_inv
+            return new_inv
+
+        return self._ndcube.meta["inventory"]
+
+    def quality_report(self, path: str | os.PathLike | None = None, overwrite: bool | None = None):
         """
         Download the quality report PDF.
 
@@ -346,24 +394,23 @@ class FileManager(BaseFileManager):
             downloaded file if the download was successful, and any errors if it
             was not.
         """
-        dataset_id = self._ndcube.meta["inventory"]["datasetId"]
-        url = f"{self._metadata_streamer_url}/quality?datasetId={dataset_id}"
+        url = f"{self._metadata_streamer_url}/quality?datasetId={self._dataset_id}"
         if path is None and self.basepath:
             path = self.basepath
         return Downloader.simple_download([url], path=path, overwrite=overwrite)
 
-    def preview_movie(self, path=None, overwrite=None):
+    def preview_movie(self, path: str | os.PathLike | None = None, overwrite: bool | None = None):
         """
         Download the preview movie.
 
         Parameters
         ----------
-        path: `str` or `pathlib.Path`
+        path
             The destination path to save the file to. See
             `parfive.Downloader.simple_download` for details.
             The default path is ``.basepath``, if ``.basepath`` is None it will
             default to `~/`.
-        overwrite: `bool`
+        overwrite
             Set to `True` to overwrite file if it already exists. See
             `parfive.Downloader.simple_download` for details.
 
@@ -374,19 +421,25 @@ class FileManager(BaseFileManager):
             downloaded file if the download was successful, and any errors if it
             was not.
         """
-        dataset_id = self._ndcube.meta["inventory"]["datasetId"]
-        url = f"{self._metadata_streamer_url}/movie?datasetId={dataset_id}"
+        url = f"{self._metadata_streamer_url}/movie?datasetId={self._dataset_id}"
         if path is None and self.basepath:
             path = self.basepath
         return Downloader.simple_download([url], path=path, overwrite=overwrite)
 
-    def download(self, path=None, destination_endpoint=None, progress=True, wait=True, label=None):
+    def download(
+        self,
+        path: str | os.PathLike | None = None,
+        destination_endpoint: str = None,
+        progress: bool = True,
+        wait: bool = True,
+        label: str = None,
+    ):
         """
         Start a Globus file transfer for all files in this Dataset.
 
         Parameters
         ----------
-        path : `pathlib.Path` or `str`, optional
+        path
             The path to save the data in, must be accessible by the Globus
             endpoint.
             The default value is ``.basepath``, if ``.basepath`` is None it will
@@ -402,36 +455,31 @@ class FileManager(BaseFileManager):
             argument, so that the array can be read from your transferred
             files.
 
-        destination_endpoint : `str`, optional
+        destination_endpoint
             A unique specifier for a Globus endpoint. If `None` a local
             endpoint will be used if it can be found, otherwise an error will
             be raised. See `~dkist.net.globus.get_endpoint_id` for valid
             endpoint specifiers.
 
-        progress : `bool` or `str`, optional
+        progress
            If `True` status information and a progress bar will be displayed
            while waiting for the transfer to complete.
            If ``progress="verbose"`` then all globus events generated during
            the transfer will be shown (by default only error messages are
            shown.)
 
-        wait : `bool`, optional
+        wait
             If `False` then the function will return while the Globus transfer task
             is still running. Setting ``wait=False`` implies ``progress=False``.
 
-        label : `str`
+        label
             Label for the Globus transfer. If `None` then a default will be used.
         """
         # Import here to prevent triggering an import of `.net` with `dkist.dataset`.
         from dkist.net import conf as net_conf
         from dkist.net.helpers import _orchestrate_transfer_task
 
-        if self._ndcube is None:
-            raise ValueError(
-                "This file manager has no associated Dataset object, so the data can not be downloaded."
-            )
-
-        inv = self._ndcube.meta["inventory"]
+        inv = self._inventory
         path_inv = path_format_inventory(humanize_inventory(inv))
 
         base_path = Path(net_conf.dataset_path.format(**inv))

--- a/dkist/io/tests/test_file_manager.py
+++ b/dkist/io/tests/test_file_manager.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import dask.array as da
@@ -161,14 +162,18 @@ def test_reprs(file_manager):
 
 
 @pytest.fixture
+def mock_inventory_refresh(mocker):
+    return mocker.patch("dkist.io.file_manager.FileManager._get_inventory",
+                        return_value=None)
+
+
+@pytest.fixture
 def orchestrate_transfer_mock(mocker):
-    mocker.patch("dkist.io.file_manager.FileManager._get_inventory",
-                 return_value=None)
     return mocker.patch("dkist.net.helpers._orchestrate_transfer_task",
                        autospec=True)
 
 
-def test_download_default_keywords(dataset, orchestrate_transfer_mock):
+def test_download_default_keywords(dataset, orchestrate_transfer_mock, mock_inventory_refresh):
     base_path = Path(net.conf.dataset_path.format(**dataset.meta["inventory"]))
     folder = Path("/{bucket}/{primaryProposalId}/{datasetId}/".format(**dataset.meta["inventory"]))
     file_list = [*dataset.files.filenames, folder / "test_dataset.asdf", folder / "test_dataset.mp4", folder / "test_dataset.pdf"]
@@ -187,6 +192,51 @@ def test_download_default_keywords(dataset, orchestrate_transfer_mock):
     )
 
 
+def test_inventory_refresh(httpserver, dataset, orchestrate_transfer_mock):
+    from dkist.net import conf
+
+    dataset_id = dataset.meta["inventory"]["datasetId"]
+
+    # Setup a happy path response
+    exp = httpserver.expect_request("/datasets/v1", query_string={"datasetIds": dataset_id})
+    exp.respond_with_json({"searchResults": [{"bucket": "notdata"}]})
+
+    # Tell the client to use the httpserver URL
+    conf.dataset_endpoint = httpserver.url_for("/datasets/")
+
+    new_inv = dataset.files._get_inventory(dataset_id)
+
+    assert new_inv == {"bucket": "notdata"}
+
+
+@pytest.mark.parametrize("error_code", [404, 202])
+def test_inventory_refresh_fails(httpserver, caplog_dkist, dataset, orchestrate_transfer_mock, error_code):
+    from dkist.net import conf
+
+    dataset_id = dataset.meta["inventory"]["datasetId"]
+
+    # Setup a happy path response
+    exp = httpserver.expect_request("/datasets/v1", query_string={"datasetIds": dataset_id})
+    exp.respond_with_data("Not Found", status=error_code)
+
+    # Tell the client to use the httpserver URL
+    conf.dataset_endpoint = httpserver.url_for("/datasets/")
+
+    new_inv = dataset.files._get_inventory(dataset_id)
+    assert ("dkist", logging.INFO, "Refreshing dataset inventory for dataset test_dataset") in caplog_dkist.record_tuples
+    if error_code == 404:
+        assert ("dkist",
+                logging.ERROR,
+                f"Inventory refresh failed with HTTP Error {error_code}: NOT FOUND") in caplog_dkist.record_tuples
+
+    if error_code == 202:
+        assert ("dkist",
+                logging.ERROR,
+                f"Inventory refresh failed with error code {error_code}") in caplog_dkist.record_tuples
+
+    assert new_inv is None
+
+
 @pytest.mark.parametrize("keywords", [
     {"progress": True, "wait": True, "destination_endpoint": None, "label": None},
     {"progress": True, "wait": False, "destination_endpoint": None, "label": None},
@@ -194,7 +244,7 @@ def test_download_default_keywords(dataset, orchestrate_transfer_mock):
     {"progress": False, "wait": True, "destination_endpoint": "wibble", "label": None},
     {"progress": False, "wait": True, "destination_endpoint": None, "label": "fibble"},
 ])
-def test_download_keywords(dataset, orchestrate_transfer_mock, keywords):
+def test_download_keywords(dataset, orchestrate_transfer_mock, mock_inventory_refresh, keywords):
     """
     Assert that keywords are passed through as expected
     """
@@ -217,7 +267,7 @@ def test_download_keywords(dataset, orchestrate_transfer_mock, keywords):
         assert dataset.files.basepath == Path("/test/")
 
 
-def test_download_path_interpolation(dataset, orchestrate_transfer_mock):
+def test_download_path_interpolation(dataset, orchestrate_transfer_mock, mock_inventory_refresh):
     base_path = Path(net.conf.dataset_path.format(**dataset.meta["inventory"]))
     folder = Path("/{bucket}/{primaryProposalId}/{datasetId}/".format(**dataset.meta["inventory"]))
     file_list = [*dataset.files.filenames, folder / "test_dataset.asdf", folder / "test_dataset.mp4", folder / "test_dataset.pdf"]

--- a/dkist/io/tests/test_file_manager.py
+++ b/dkist/io/tests/test_file_manager.py
@@ -162,6 +162,8 @@ def test_reprs(file_manager):
 
 @pytest.fixture
 def orchestrate_transfer_mock(mocker):
+    mocker.patch("dkist.io.file_manager.FileManager._get_inventory",
+                 return_value=None)
     return mocker.patch("dkist.net.helpers._orchestrate_transfer_task",
                        autospec=True)
 

--- a/dkist/net/client.py
+++ b/dkist/net/client.py
@@ -168,7 +168,7 @@ class DKISTClient(BaseClient):
 
     def search(self, *args) -> DKISTQueryResponseTable:
         """
-        Search for datasets provided by the DKIST data centre.
+        Search for datasets provided by the DKIST data center.
         """
         from dkist.net import conf
 
@@ -180,8 +180,9 @@ class DKISTClient(BaseClient):
             if "pageSize" not in url_parameters:
                 url_parameters.update({"pageSize": conf.default_page_size})
             # TODO make this accept and concatenate multiple wavebands in a search
-            query_string = urllib.parse.urlencode(url_parameters, doseq=True)
-            full_url = f"{self._dataset_search_url}?{query_string}"
+            parsed = list(urllib.parse.urlparse(self._dataset_search_url))
+            parsed[4] = urllib.parse.urlencode(url_parameters, doseq=True)
+            full_url = urllib.parse.urlunparse(parsed)
             data = urllib.request.urlopen(full_url)
             data = json.loads(data.read())
             results.append(data)

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,7 @@ norecursedirs =
     .history
     dkist/extern
     tools/
-	.hypothesis
+    .hypothesis
 doctest_plus = enabled
 doctest_optionflags =
     NORMALIZE_WHITESPACE

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ norecursedirs =
     .history
     dkist/extern
     tools/
+	.hypothesis
 doctest_plus = enabled
 doctest_optionflags =
     NORMALIZE_WHITESPACE


### PR DESCRIPTION
Adds a mitigation to the `/data` `/public` bucket moving by pulling the latest copy of inventory before downloading the FITS files.

The code is pretty happy to accept that refresh failing to not cause errors in weird places.