### PR TITLE
Dirty fix downstream job

### DIFF
--- a/.github/workflows/dkist_downstreams.yml
+++ b/.github/workflows/dkist_downstreams.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -132,10 +132,12 @@ description = Run the dkist-inventory tests against this version of dkist
 base_python = py311  # dkist-inventory is fussy about python version
 extras = # we don't need dkist test extras
 allowlist_externals = git, rm, bash
-commands =
+commands_pre =
     bash -c 'rm -rf dkist-inventory || true'
     git clone https://bitbucket.org/dkistdc/dkist-inventory.git
-    python -m pip install "./dkist-inventory[test]"
+    python -m pip install "./dkist-inventory[test]" {toxinidir}
+    pip freeze --all --no-input
+commands =
     python -m pytest dkist-inventory {posargs}
 
 [testenv:dkist-processing-common]
@@ -143,8 +145,10 @@ description = Run the dkist-processing-common tests against this version of dkis
 base_python = py311  # dkist-inventory is fussy about python version
 extras = # we don't need dkist test extras
 allowlist_externals = git, rm, bash
-commands =
+commands_pre =
     bash -c 'rm -rf dkist-processing-common || true'
     git clone https://bitbucket.org/dkistdc/dkist-processing-common.git
-    python -m pip install "./dkist-processing-common[test,asdf]"
+    python -m pip install "./dkist-processing-common[test,asdf]" {toxinidir}
+    pip freeze --all --no-input
+commands =
     python -m pytest dkist-processing-common -m "not development" {posargs}


### PR DESCRIPTION
This fixes the downstream tests so that installing the package under test doesn't accidentality install the release version of dkist.