### PR TITLE
Update transform schemas to support transform-1.4.0 schema

### DIFF
--- a/changelog/568.feature.rst
+++ b/changelog/568.feature.rst
@@ -1,0 +1,1 @@
+Add support for new transform schemas in asdf-transform-schemas 0.6.0.

--- a/dkist/io/asdf/entry_points.py
+++ b/dkist/io/asdf/entry_points.py
@@ -49,6 +49,8 @@ def get_extensions():
                                    converters=dkist_converters),
         ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-1.0.0",
                                    converters=dkist_converters),
+        ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-wcs-1.5.0",
+                                   converters=wcs_converters),
         ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-wcs-1.4.0",
                                    converters=wcs_converters),
         ManifestExtension.from_uri("asdf://dkist.nso.edu/manifests/dkist-wcs-1.3.0",

--- a/dkist/io/asdf/resources/manifests/dkist-wcs-1.5.0.yaml
+++ b/dkist/io/asdf/resources/manifests/dkist-wcs-1.5.0.yaml
@@ -1,0 +1,27 @@
+%YAML 1.1
+---
+id: asdf://dkist.nso.edu/manifests/dkist-wcs-1.5.0
+extension_uri: asdf://dkist.nso.edu/dkist/extensions/dkist-wcs-1.5.0
+asdf_standard_requirement:
+  gte: 1.6.0
+
+title: DKIST WCS extension
+description: ASDF schemas and tags for models and WCS related classes.
+
+tags:
+  # the tag version does not match the schema version
+  - schema_uri: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.3.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/varying_celestial_transform-1.4.0"
+
+  # the varying_celestial_transform schema is reused here
+  - schema_uri: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.3.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/inverse_varying_celestial_transform-1.4.0"
+
+  - schema_uri: "asdf://dkist.nso.edu/schemas/coupled_compound_model-1.2.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/coupled_compound_model-1.2.0"
+
+  - schema_uri: "asdf://dkist.nso.edu/schemas/ravel_model-1.2.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/ravel_model-1.2.0"
+
+  - schema_uri: "asdf://dkist.nso.edu/schemas/asymmetric_mapping_model-1.2.0"
+    tag_uri: "asdf://dkist.nso.edu/tags/asymmetric_mapping_model-1.2.0"

--- a/dkist/io/asdf/resources/schemas/asymmetric_mapping_model-1.2.0.yaml
+++ b/dkist/io/asdf/resources/schemas/asymmetric_mapping_model-1.2.0.yaml
@@ -1,0 +1,30 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://dkist.nso.edu/schemas/asymmetric_mapping_model-1.2.0"
+title: >
+  Reorder, add and drop axes with different mappings in forward and reverse transforms.
+
+definitions:
+  mapping:
+    type: array
+    items:
+      type: integer
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - properties:
+      forward_n_inputs:
+        description: |
+          Explicitly set the number of input axes in the forward direction.
+        type: integer
+      backward_n_inputs:
+        description: |
+          Explicitly set the number of input axes in the backward direction.
+        type: integer
+      forward_mapping:
+        $ref: "#/definitions/mapping"
+      backward_mapping:
+        $ref: "#/definitions/mapping"
+    required: [forward_mapping, backward_mapping]
+...

--- a/dkist/io/asdf/resources/schemas/coupled_compound_model-1.2.0.yaml
+++ b/dkist/io/asdf/resources/schemas/coupled_compound_model-1.2.0.yaml
@@ -1,0 +1,85 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://dkist.nso.edu/schemas/coupled_compound_model-1.2.0"
+title: >
+  Send axes to different subtransforms.
+description: |
+    This transform takes two models which share one or more inputs on the forward
+    transform, and where the left hand model's inverse is dependent on the
+    output of the right hand model's inverse output.
+
+    Take the following example with a time dependent celestial transform
+    (modelled as dependent upon the pixel coordinate for time rather than the
+    world coordinate).
+
+    The forward transform uses the "z" pixel dimension as input to both the
+    Celestial and Temporal models, this leads to the following transform in the
+    forward direction:
+
+    ```
+      :    x  y           z
+      :    │  │           │
+      :    │  │  ┌────────┤
+      :    │  │  │        │
+      :    ▼  ▼  ▼        ▼
+      :  ┌─────────┐  ┌────────┐
+      :  │Celestial│  │Temporal│
+      :  └─┬───┬───┘  └───┬────┘
+      :    │   │          │
+      :    │   │          │
+      :    │   │          │
+      :    ▼   ▼          ▼
+      :   lon lat       time
+    ```
+
+    The complexity is in the reverse transform, where the inverse Celestial
+    transform is also dependent upon the pixel coordinate z.
+    This means that the output of the inverse Temporal transform has to be
+    duplicated as an input to the Celestial transform's inverse.
+    This is achieved by the use of the ``Mapping`` models in
+    ``CoupledCompoundModel.inverse`` to create a multi-stage compound model
+    which duplicates the output of the right hand side model::
+
+    ```
+      :   lon lat       time
+      :    │   │         │
+      :    │   │         ▼
+      :    │   │     ┌─────────┐
+      :    │   │     │Temporal'│
+      :    │   │     └──┬──┬───┘
+      :    │   │    z   │  │
+      :    │   │  ┌─────┘  │
+      :    │   │  │        │
+      :    ▼   ▼  ▼        │
+      :  ┌──────────┐      │
+      :  │Celestial'│      │
+      :  └─┬───┬────┘      │
+      :    │   │           │
+      :    ▼   ▼           ▼
+      :    x   y           z
+    ```
+
+examples:
+  -
+    - A set of transforms
+    - asdf-standard-1.6.0
+    - |
+      !<asdf://dkist.nso.edu/tags/coupled_compound_model-1.2.0>
+        shared_inputs: 1
+        forward:
+          - !transform/shift-1.4.0
+            offset: 2.0
+          - !transform/shift-1.4.0
+            offset: 3.0
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - properties:
+      forward:
+        type: array
+        items:
+          $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+      shared_inputs:
+        type: number
+    required: [forward, shared_inputs]
+...

--- a/dkist/io/asdf/resources/schemas/coupled_compound_model-1.2.0.yaml
+++ b/dkist/io/asdf/resources/schemas/coupled_compound_model-1.2.0.yaml
@@ -68,9 +68,9 @@ examples:
       !<asdf://dkist.nso.edu/tags/coupled_compound_model-1.2.0>
         shared_inputs: 1
         forward:
-          - !transform/shift-1.4.0
+          - !transform/shift-1.3.0
             offset: 2.0
-          - !transform/shift-1.4.0
+          - !transform/shift-1.3.0
             offset: 3.0
 allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"

--- a/dkist/io/asdf/resources/schemas/ravel_model-1.2.0.yaml
+++ b/dkist/io/asdf/resources/schemas/ravel_model-1.2.0.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://dkist.nso.edu/schemas/ravel_model-1.2.0"
+
+title: A model to flatten 2D indices into 1D
+description:
+  A model which takes a pair of indices and flattens them into the corresponding index for a 1D array. This can be used as a compound with Tabular1D to enable it to be indexed as if it were Tabular2D.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - properties:
+      array_shape:
+        type: array
+      order:
+        type: string
+    required: [array_shape, order]

--- a/dkist/io/asdf/resources/schemas/varying_celestial_transform-1.3.0.yaml
+++ b/dkist/io/asdf/resources/schemas/varying_celestial_transform-1.3.0.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "asdf://dkist.nso.edu/schemas/varying_celestial_transform-1.3.0"
+
+title: A varying FITS-like celestial transform.
+description:
+  A model which represents a FITS-like celestial WCS transform which varies over a third pixel input.
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+  - properties:
+      crpix_table:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      cdelt:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      lon_pole:
+        anyOf:
+          - type: number
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      crval_table:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      pc_table:
+        anyOf:
+          - tag: "tag:stsci.edu:asdf/core/ndarray-1.*"
+          - tag: "tag:stsci.edu:asdf/unit/quantity-1.*"
+      projection:
+        $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.4.0"
+
+    required: [crpix_table, cdelt, lon_pole, crval_table, pc_table, projection]
+    additionalProperties: true
+...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ dependencies = [
   "asdf-astropy>=0.5.0",  # Required by gwcs 0.24
   "asdf-coordinates-schemas>=0.3.0",  # required by wcs-schemas 0.4
   "asdf-standard>=1.1.0",
-  #"asdf-transform-schemas>=0.5.0",  # required by wcs-schemas 0.4
-  "asdf-transform-schemas @ git+https://github.com/asdf-format/asdf-transform-schemas",
+  "asdf-transform-schemas>=0.6.0",
   "asdf-wcs-schemas>=0.4.0",  # required by gwcs 0.24
   "astropy>=6.0",  # required by gwcs 0.24
   "dask[array]>=2023.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
   "asdf-astropy>=0.5.0",  # Required by gwcs 0.24
   "asdf-coordinates-schemas>=0.3.0",  # required by wcs-schemas 0.4
   "asdf-standard>=1.1.0",
-  "asdf-transform-schemas>=0.5.0",  # required by wcs-schemas 0.4
+  #"asdf-transform-schemas>=0.5.0",  # required by wcs-schemas 0.4
+  "asdf-transform-schemas @ git+https://github.com/asdf-format/asdf-transform-schemas",
   "asdf-wcs-schemas>=0.4.0",  # required by gwcs 0.24
   "astropy>=6.0",  # required by gwcs 0.24
   "dask[array]>=2023.2.0",


### PR DESCRIPTION
A new version of asdf-transform-schemas will soon be released with a new transform-1.4.0 schema. See https://github.com/asdf-format/asdf-transform-schemas/pull/120 for more details on the motivation for the new schema (tldr; this decouples the transform schemas from the core schemas in the standard to allow easier fixes for things like the ndarray mask bug: https://github.com/asdf-format/asdf/issues/1909).

This PR updates the dkist wcs schemas to use the new transform-1.4.0 schema.

A related asdf-astropy PR (https://github.com/astropy/asdf-astropy/pull/279) includes checks to verify the updates don't break the current dkist release due to a sort of self-referencing issue with the now old transform-1.3.0 schema. That PR makes the assumption that the dkist changes in this PR will end up in manifest 1.5.0.

This PR is part of an effort to untangle some dependencies in transform schemas. See https://github.com/asdf-format/asdf-wcs-schemas/pull/68 for probably too much context.