### PR TITLE
Only run benchmarks CI when dkist/ is changed

### DIFF
--- a/.github/workflows/codspeed-walltime.yml
+++ b/.github/workflows/codspeed-walltime.yml
@@ -8,6 +8,8 @@ on:
     types:
       - synchronize
       - labeled
+    paths:
+      - "dkist/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "dkist/**"
   pull_request:
+    paths:
+      - "dkist/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
There's no need to benchmark PRs if they only change the docs or infra code.