### PR TITLE
use new pytest asdf plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 tests = [
   "pytest",
+  "pytest-asdf-plugin",
   "pytest-doctestplus",
   "pytest-cov",
   "pytest-remotedata",


### PR DESCRIPTION
Update test dependencies to use new https://pypi.org/project/pytest-asdf-plugin/ which is a feature-compatible replacement for the bundled asdf pytest plugin (which will soon be deprecated).

For context the pytest-asdf-plugin is responsible for finding and converting schema files into "tests" (to check the schema against the metaschema and validated any contained "examples"). Since both the bundled and now external plugins are feature-compatible there should be no change in test number (or new failures, etc).

On main 443 tests passed:
https://github.com/DKISTDC/dkist/actions/runs/17036230456/job/48289274225#step:10:639

With this PR 443 tests passed:
https://github.com/DKISTDC/dkist/actions/runs/17048153911/job/48329094771?pr=610#step:10:638