### PR TITLE
Add support for remote file URIs

### DIFF
--- a/changelog/738.feature.rst
+++ b/changelog/738.feature.rst
@@ -1,0 +1,1 @@
+`dkist.load_dataset` now accepts remote URLs (e.g. ``s3://``) for both ASDF files and dataset directories, and ``Dataset.files.basepath`` can be set to a remote location, with the ASDF and FITS files read through `fsspec`. Reading from S3 additionally requires the ``s3fs`` package to be installed.

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -120,7 +120,10 @@ def _load_from_string(path: str, *, ignore_version_mismatch=False):
     """
     A string representing a directory or an ASDF file.
     """
-    # TODO Adjust this to accept URLs as well
+    if "://" in path:
+        from upath import UPath  # noqa: PLC0415
+
+        return _load_from_path(UPath(path), ignore_version_mismatch=ignore_version_mismatch)
     return _load_from_path(Path(path), ignore_version_mismatch=ignore_version_mismatch)
 
 
@@ -165,7 +168,7 @@ def _load_from_directory(directory, *, ignore_version_mismatch=False):
     - Ignore any ASDF files with an old suffix if a new suffix is present
     - Throw a warning to the user if any ASDF files with older suffixes are found
     """
-    base_path = Path(directory).expanduser()
+    base_path = Path(directory).expanduser() if isinstance(directory, str) else directory
     asdf_files = tuple(base_path.glob("*.asdf"))
 
     if not asdf_files:
@@ -229,7 +232,9 @@ def _load_from_asdf(filepath, *, ignore_version_mismatch=False):
     from dkist.dataset import Dataset, Inversion, TiledDataset  # noqa: PLC0415
 
     # Load the file without a custom schema so that we can validate it against multiple schemas
-    with asdf.open(filepath, lazy_load=False, memmap=False) as ff:
+    with filepath.open(mode="rb") as fileobj, asdf.open(
+        fileobj, lazy_load=False, memmap=False
+    ) as ff:
         if not ignore_version_mismatch:
             _check_dkist_version(filepath, ff)
 

--- a/dkist/dataset/loader.py
+++ b/dkist/dataset/loader.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 
 from packaging.version import Version
 from parfive import Results
+from upath import UPath
 
 import asdf
 
@@ -118,13 +119,19 @@ def _load_from_iterable(iterable: tuple | list, *, ignore_version_mismatch=False
 @load_dataset.register
 def _load_from_string(path: str, *, ignore_version_mismatch=False):
     """
-    A string representing a directory or an ASDF file.
+    A string representing a directory, an ASDF file, or a remote URL (e.g. ``s3://``).
     """
     if "://" in path:
-        from upath import UPath  # noqa: PLC0415
-
         return _load_from_path(UPath(path), ignore_version_mismatch=ignore_version_mismatch)
     return _load_from_path(Path(path), ignore_version_mismatch=ignore_version_mismatch)
+
+
+@load_dataset.register
+def _load_from_upath(path: UPath, *, ignore_version_mismatch=False):
+    """
+    A `~upath.UPath` object representing a local or remote directory or ASDF file.
+    """
+    return _load_from_path(path, ignore_version_mismatch=ignore_version_mismatch)
 
 
 @load_dataset.register

--- a/dkist/dataset/tests/test_load_dataset.py
+++ b/dkist/dataset/tests/test_load_dataset.py
@@ -310,6 +310,7 @@ def test_version_error_string_and_iterable(asdf_extensions):
     ds = load_dataset([test_file], ignore_version_mismatch=True)
     assert isinstance(ds, Dataset)
 
+
 @pytest.fixture
 def small_visp_memory_url():
     # Copy the small VISP dataset (ASDF plus FITS files) into an in-memory

--- a/dkist/dataset/tests/test_load_dataset.py
+++ b/dkist/dataset/tests/test_load_dataset.py
@@ -3,8 +3,11 @@ import shutil
 import numbers
 import contextlib
 
+import fsspec
+import numpy as np
 import pytest
 from parfive import Results
+from upath import UPath
 
 import asdf
 from asdf.tags.core import ExtensionMetadata, Software
@@ -306,3 +309,43 @@ def test_version_error_string_and_iterable(asdf_extensions):
 
     ds = load_dataset([test_file], ignore_version_mismatch=True)
     assert isinstance(ds, Dataset)
+
+@pytest.fixture
+def small_visp_memory_url():
+    # Copy the small VISP dataset (ASDF plus FITS files) into an in-memory
+    # fsspec filesystem, which behaves like any remote filesystem (e.g. S3)
+    # without needing network access.
+    fs = fsspec.filesystem("memory")
+    src = rootdir / "small_visp"
+    for file in src.iterdir():
+        fs.pipe_file(f"/small_visp/{file.name}", file.read_bytes())
+    yield "memory://small_visp"
+    fs.rm("/small_visp", recursive=True)
+
+
+@pytest.mark.parametrize("asdf_suffix", ["", "/test_visp.asdf"])
+def test_load_dataset_remote_url(small_visp_memory_url, asdf_suffix):
+    # Both the directory and direct ASDF file forms of a remote URL should
+    # load, keep a remote basepath, and read the FITS data through fsspec.
+    ds = load_dataset(small_visp_memory_url + asdf_suffix)
+    assert isinstance(ds, Dataset)
+    assert isinstance(ds.files.basepath, UPath)
+
+    reference = load_dataset(rootdir / "small_visp")
+    np.testing.assert_array_equal(np.asarray(ds.data), np.asarray(reference.data))
+
+
+def test_load_dataset_upath(small_visp_memory_url):
+    ds = load_dataset(UPath(small_visp_memory_url))
+    assert isinstance(ds, Dataset)
+    assert isinstance(ds.files.basepath, UPath)
+
+
+def test_basepath_remote_url(small_visp_memory_url):
+    # Setting basepath to a remote URL string should be preserved rather than
+    # mangled into a local path, and data reads should go through fsspec.
+    ds = load_dataset(rootdir / "small_visp")
+    reference = np.asarray(ds.data)
+    ds.files.basepath = small_visp_memory_url
+    assert isinstance(ds.files.basepath, UPath)
+    np.testing.assert_array_equal(np.asarray(ds.data), reference)

--- a/dkist/io/dask/loaders.py
+++ b/dkist/io/dask/loaders.py
@@ -92,10 +92,11 @@ class AstropyFITSLoader(BaseFITSLoader):
             # which only uses memory for one value.
             return np.broadcast_to((np.nan,), self.shape) * np.nan
 
-        with fits.open(self.absolute_uri,
-                       memmap=False,  # memmap is redundant with dask and delayed loading
-                       do_not_scale_image_data=True,  # don't scale as we shouldn't need to
-                       mode="denywrite") as hdul:
+        with self.absolute_uri.open(mode="rb") as fileobj, fits.open(
+            fileobj,
+            memmap=False,  # memmap is redundant with dask and delayed loading
+            do_not_scale_image_data=True,  # don't scale as we shouldn't need to
+        ) as hdul:
             log.debug("Accessing slice %s from file %s", slc, self.absolute_uri)
 
             hdu = hdul[self.target]

--- a/dkist/io/dask/striped_array.py
+++ b/dkist/io/dask/striped_array.py
@@ -39,10 +39,10 @@ class FileManagerProtocol(Protocol):
     """
 
     @property
-    def basepath(self) -> os.PathLike: ...
+    def basepath(self) -> Path | UPath | None: ...
 
     @basepath.setter
-    def basepath(self, path: str | os.PathLike) -> None: ...
+    def basepath(self, path: str | os.PathLike | UPath) -> None: ...
 
     @property
     def filenames(self) -> list[str]: ...
@@ -166,19 +166,20 @@ class StripedExternalArray(BaseStripedExternalArray):
             return UPath(value)
         if isinstance(value, UPath):
             # Keep fsspec-backed paths as they are; converting them to a plain
-            # Path would mangle the URL
-            return value
+            # Path would mangle the URL. expanduser only has an effect on
+            # local filesystem paths.
+            return value.expanduser()
         return Path(value).expanduser()
 
     @property
-    def basepath(self) -> os.PathLike:
+    def basepath(self) -> Path | UPath | None:
         """
         The path all arrays generated from this ``FileManager`` use to read data from.
         """
         return self._basepath
 
     @basepath.setter
-    def basepath(self, value: os.PathLike | str | None):
+    def basepath(self, value: os.PathLike | UPath | str | None):
         self._basepath = self._sanitize_basepath(value)
         for loader in self._loader_array.flat:
             loader.basepath = self._basepath
@@ -223,7 +224,7 @@ class StripedExternalArrayView(BaseStripedExternalArray):
         return dedent(f"{prefix}\n{self.__str__()}")
 
     @property
-    def basepath(self) -> os.PathLike:
+    def basepath(self) -> Path | UPath | None:
         """
         The path all arrays generated from this ``FileManager`` use to read data from.
         """

--- a/dkist/io/dask/striped_array.py
+++ b/dkist/io/dask/striped_array.py
@@ -22,6 +22,7 @@ from collections.abc import Iterable
 import dask.array
 import numpy as np
 from numpy.typing import DTypeLike, NDArray
+from upath import UPath
 
 from astropy.wcs.wcsapi.wrappers.sliced_wcs import sanitize_slices
 
@@ -162,18 +163,11 @@ class StripedExternalArray(BaseStripedExternalArray):
         if value is None:
             return None
         if isinstance(value, str) and "://" in value:
-            from upath import UPath  # noqa: PLC0415
-
             return UPath(value)
-        try:
-            from upath import UPath  # noqa: PLC0415
-        except ImportError:
-            pass
-        else:
+        if isinstance(value, UPath):
             # Keep fsspec-backed paths as they are; converting them to a plain
             # Path would mangle the URL
-            if isinstance(value, UPath):
-                return value
+            return value
         return Path(value).expanduser()
 
     @property

--- a/dkist/io/dask/striped_array.py
+++ b/dkist/io/dask/striped_array.py
@@ -159,7 +159,22 @@ class StripedExternalArray(BaseStripedExternalArray):
 
     @staticmethod
     def _sanitize_basepath(value):
-        return Path(value).expanduser() if value is not None else None
+        if value is None:
+            return None
+        if isinstance(value, str) and "://" in value:
+            from upath import UPath  # noqa: PLC0415
+
+            return UPath(value)
+        try:
+            from upath import UPath  # noqa: PLC0415
+        except ImportError:
+            pass
+        else:
+            # Keep fsspec-backed paths as they are; converting them to a plain
+            # Path would mangle the URL
+            if isinstance(value, UPath):
+                return value
+        return Path(value).expanduser()
 
     @property
     def basepath(self) -> os.PathLike:

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -5,7 +5,7 @@ This file contains the DKIST specific FileManager code.
 import os
 import json
 import urllib
-from typing import Any
+from typing import Any, cast
 from pathlib import Path
 from textwrap import dedent
 
@@ -25,6 +25,18 @@ def _is_remote(path):
     Return `True` if ``path`` is an fsspec-backed path to a remote filesystem.
     """
     return isinstance(path, UPath) and path.protocol not in ("", "file", "local")
+
+
+def _local_basepath(basepath: Path | UPath | None) -> str | os.PathLike | None:
+    """
+    Return ``basepath`` for use as a local download destination, or `None` if
+    it is a remote location.
+    """
+    if _is_remote(basepath):
+        return None
+    # A non-remote basepath is either a Path or a UPath on the local
+    # filesystem, both of which implement the os.PathLike interface
+    return cast("str | os.PathLike | None", basepath)
 
 
 class DKISTFileManager:
@@ -184,8 +196,8 @@ class DKISTFileManager:
             raise ValueError(msg)
 
         url = f"{self._metadata_streamer_url}/quality?datasetId={self._dataset_id}"
-        if path is None and self.basepath and not _is_remote(self.basepath):
-            path = self.basepath
+        if path is None:
+            path = _local_basepath(self.basepath)
         kwargs = {}
         if normalized_format == "json":
             kwargs["headers"] = {"Accept": "application/json"}
@@ -216,8 +228,8 @@ class DKISTFileManager:
             was not.
         """
         url = f"{self._metadata_streamer_url}/movie?datasetId={self._dataset_id}"
-        if path is None and self.basepath and not _is_remote(self.basepath):
-            path = self.basepath
+        if path is None:
+            path = _local_basepath(self.basepath)
         return Downloader.simple_download([url], path=path, overwrite=overwrite)
 
     def download(
@@ -277,8 +289,7 @@ class DKISTFileManager:
         path_inv = path_format_inventory(humanize_inventory(inv))
 
         base_path = Path(net_conf.dataset_path.format(**inv))
-        local_basepath = None if _is_remote(self.basepath) else self.basepath
-        destination_path = path or local_basepath or "/~/"
+        destination_path = path or _local_basepath(self.basepath) or "/~/"
         destination_path = Path(destination_path).as_posix()
         destination_path = Path(destination_path.format(**path_inv))
 

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from textwrap import dedent
 
 from parfive import Downloader, Results
+from upath import UPath
 
 from dkist import log
 from dkist.io.dask.striped_array import FileManager, FileManagerProtocol
@@ -17,6 +18,13 @@ from dkist.io.utils import filemanager_info_str
 from dkist.utils.inventory import humanize_inventory, path_format_inventory
 
 __all__ = ["DKISTFileManager"]
+
+
+def _is_remote(path):
+    """
+    Return `True` if ``path`` is an fsspec-backed path to a remote filesystem.
+    """
+    return isinstance(path, UPath) and path.protocol not in ("", "file", "local")
 
 
 class DKISTFileManager:
@@ -63,14 +71,14 @@ class DKISTFileManager:
         return dedent(f"{prefix}\n{self.__str__()}")
 
     @property
-    def basepath(self) -> os.PathLike:
+    def basepath(self) -> Path | UPath | None:
         """
         The path all arrays read data from.
         """
         return self._fm.basepath
 
     @basepath.setter
-    def basepath(self, basepath: str | os.PathLike):
+    def basepath(self, basepath: str | os.PathLike | UPath):
         self._fm.basepath = basepath
 
     def __getattr__(self, attr):
@@ -154,8 +162,8 @@ class DKISTFileManager:
         path
             The destination path to save the file to. See
             `parfive.Downloader.simple_download` for details.
-            The default path is ``.basepath``, if ``.basepath`` is None it will
-            default to `~/`.
+            The default path is ``.basepath``, if ``.basepath`` is `None` or a
+            remote location it will default to `~/`.
         overwrite
             Set to `True` to overwrite file if it already exists. See
             `parfive.Downloader.simple_download` for details.
@@ -176,7 +184,7 @@ class DKISTFileManager:
             raise ValueError(msg)
 
         url = f"{self._metadata_streamer_url}/quality?datasetId={self._dataset_id}"
-        if path is None and self.basepath:
+        if path is None and self.basepath and not _is_remote(self.basepath):
             path = self.basepath
         kwargs = {}
         if normalized_format == "json":
@@ -194,8 +202,8 @@ class DKISTFileManager:
         path
             The destination path to save the file to. See
             `parfive.Downloader.simple_download` for details.
-            The default path is ``.basepath``, if ``.basepath`` is None it will
-            default to `~/`.
+            The default path is ``.basepath``, if ``.basepath`` is `None` or a
+            remote location it will default to `~/`.
         overwrite
             Set to `True` to overwrite file if it already exists. See
             `parfive.Downloader.simple_download` for details.
@@ -208,7 +216,7 @@ class DKISTFileManager:
             was not.
         """
         url = f"{self._metadata_streamer_url}/movie?datasetId={self._dataset_id}"
-        if path is None and self.basepath:
+        if path is None and self.basepath and not _is_remote(self.basepath):
             path = self.basepath
         return Downloader.simple_download([url], path=path, overwrite=overwrite)
 
@@ -228,8 +236,8 @@ class DKISTFileManager:
         path
             The path to save the data in, must be accessible by the Globus
             endpoint.
-            The default value is ``.basepath``, if ``.basepath`` is None it will
-            default to ``/~/``.
+            The default value is ``.basepath``, if ``.basepath`` is `None` or a
+            remote location it will default to ``/~/``.
             It is possible to put placeholder strings in the path with any key
             from the dataset inventory dictionary which can be accessed as
             ``ds.meta['inventory']``. An example of this would be
@@ -269,7 +277,8 @@ class DKISTFileManager:
         path_inv = path_format_inventory(humanize_inventory(inv))
 
         base_path = Path(net_conf.dataset_path.format(**inv))
-        destination_path = path or self.basepath or "/~/"
+        local_basepath = None if _is_remote(self.basepath) else self.basepath
+        destination_path = path or local_basepath or "/~/"
         destination_path = Path(destination_path).as_posix()
         destination_path = Path(destination_path.format(**path_inv))
 

--- a/dkist/io/file_manager.py
+++ b/dkist/io/file_manager.py
@@ -71,7 +71,7 @@ class DKISTFileManager:
 
     @basepath.setter
     def basepath(self, basepath: str | os.PathLike):
-        self._fm.basepath = Path(basepath)
+        self._fm.basepath = basepath
 
     def __getattr__(self, attr):
         # We want to proxy a fixed list of public API:

--- a/dkist/io/tests/test_file_manager.py
+++ b/dkist/io/tests/test_file_manager.py
@@ -41,6 +41,16 @@ def test_download_default_keywords(dataset, orchestrate_transfer_mock, mock_inve
     )
 
 
+def test_download_remote_basepath(dataset, orchestrate_transfer_mock, mock_inventory_refresh):
+    # A remote basepath can not be used as the Globus destination, so the
+    # default destination should be the same as when basepath is not set.
+    dataset.files.basepath = "memory://some/remote/location"
+
+    dataset.files.download()
+
+    assert orchestrate_transfer_mock.call_args.kwargs["destination_path"] == Path("/~")
+
+
 @pytest.fixture
 def httpserver_dataset_endpoint(httpserver):
     old = conf.dataset_endpoint
@@ -232,6 +242,21 @@ def test_download_quality_invalid_format(small_visp_dataset):
         small_visp_dataset.files.quality_report(format="xml")
 
 
+def test_download_quality_remote_basepath(mocker, small_visp_dataset):
+    # A remote basepath should not be used as the default download path
+    downloader = mocker.patch("dkist.io.file_manager.Downloader")
+    dataset_id = small_visp_dataset.meta["inventory"]["datasetId"]
+
+    small_visp_dataset.files.basepath = "memory://some/remote/location"
+    small_visp_dataset.files.quality_report()
+
+    downloader.return_value.enqueue_file.assert_called_once_with(
+        f"{conf.download_endpoint}/quality?datasetId={dataset_id}",
+        path=None,
+        overwrite=None,
+    )
+
+
 @pytest.mark.parametrize("kwargs", [
     {},
     {"path": "~/", "overwrite": True}
@@ -250,6 +275,20 @@ def test_download_quality_movie(mocker, small_visp_dataset, kwargs):
     simple_download.assert_called_once_with(
         [f"{conf.download_endpoint}/movie?datasetId={small_visp_dataset.meta['inventory']['datasetId']}"],
         **kwargs
+    )
+
+
+def test_download_quality_movie_remote_basepath(mocker, small_visp_dataset):
+    # A remote basepath should not be used as the default download path
+    simple_download = mocker.patch("dkist.io.file_manager.Downloader.simple_download")
+
+    small_visp_dataset.files.basepath = "memory://some/remote/location"
+    small_visp_dataset.files.preview_movie()
+
+    simple_download.assert_called_once_with(
+        [f"{conf.download_endpoint}/movie?datasetId={small_visp_dataset.meta['inventory']['datasetId']}"],
+        path=None,
+        overwrite=None,
     )
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,6 +123,7 @@ intersphinx_mapping = {
     "asdf": ("https://asdf.readthedocs.io/en/stable/", None),
     "dask": ("https://dask.pydata.org/en/stable/", None),
     "reproject": ("https://reproject.readthedocs.io/en/stable/", None),
+    "upath": ("https://universal-pathlib.readthedocs.io/en/stable/", None),
     "data-products": ("https://docs.dkist.nso.edu/projects/data-products/en/stable/", None),
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "packaging>=25.0",
   "sunpy[net,asdf]>=6",
   "tqdm>=4.65",
+  "universal_pathlib>=0.2.6",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
I wanted to do some experiments with reproject and coiled and I need the dataset to live on S3, but currently S3 URIs don't work when trying to load a dataset. Adding support for this isn't too hard as astropy already supports reading FITS files from S3, though I might be missing something, so just let me know. Also feel free to close if this is out of scope.

This is based off #737 and should be rebased when/if that PR is merged