### PR TITLE
Add `qualityDataObjectKey` to the inventory pretty names

### DIFF
--- a/changelog/748.feature.rst
+++ b/changelog/748.feature.rst
@@ -1,0 +1,1 @@
+Add a human readable name for the ``qualityDataObjectKey`` inventory key, which is displayed as "Quality Data Filename" and can be used as the ``{quality_data_filename}`` path interpolation key.

--- a/dkist/utils/inventory.py
+++ b/dkist/utils/inventory.py
@@ -61,6 +61,7 @@ INVENTORY_KEY_MAP: dict[str, str] = DefaultMap(None, {
         "averageDatasetSpatialSampling": "Average Spatial Sampling",
         "averageDatasetTemporalSampling": "Average Temporal Sampling",
         "qualityReportObjectKey": "Quality Report Filename",
+        "qualityDataObjectKey": "Quality Data Filename",
         "inputDatasetParametersPartId": "Input Dataset Parameters Part ID",
         "inputDatasetObserveFramesPartId": "Input Dataset Observe Frames Part ID",
         "inputDatasetCalibrationFramesPartId": "Input Dataset Calibration Frames Part ID",

--- a/dkist/utils/tests/test_inventory.py
+++ b/dkist/utils/tests/test_inventory.py
@@ -7,18 +7,23 @@ from dkist.utils.inventory import (_path_format_table, dehumanize_inventory,
 def test_humanize_loop():
     inv = {
         "hasSpectralAxis": True,
+        "qualityDataObjectKey": "pid_1_123/BDNEK/BDNEK_quality_data.json",
         "notAKey": "wibble"
     }
 
     new_inv = humanize_inventory(inv)
     assert "Has Spectral Axis" in new_inv
     assert "hasSpectralAxis" not in new_inv
+    assert "Quality Data Filename" in new_inv
+    assert "qualityDataObjectKey" not in new_inv
     assert "notAKey" in new_inv
 
     old_inv = dehumanize_inventory(new_inv)
 
     assert "Has Spectral Axis" not in old_inv
     assert "hasSpectralAxis" in old_inv
+    assert "Quality Data Filename" not in old_inv
+    assert "qualityDataObjectKey" in old_inv
     assert "notAKey" in old_inv
 
 


### PR DESCRIPTION
Fixes #649.

Adds `"qualityDataObjectKey": "Quality Data Filename"` to `INVENTORY_KEY_MAP`, so the key is translated in search results and gets a `quality_data_filename` path interpolation key, matching the existing `qualityReportObjectKey` -> `"Quality Report Filename"`.

I checked what the API actually returns for the key before picking the name:

```
'qualityReportObjectKey' = 'pid_1_123/BDNEK/BDNEK_quality_report.pdf'
'qualityDataObjectKey'   = 'pid_1_123/BDNEK/BDNEK_quality_data.json'
```

so "Quality Data Filename" seemed like the natural counterpart, but I'm happy to rename it if you'd prefer something that makes the PDF/JSON distinction more explicit.

Extended `test_humanize_loop` to round-trip the new key rather than adding a separate test, since it's exactly what that test is for. The fixed keymap in `test_path_format_table` is deliberately untouched — it's independent of `INVENTORY_KEY_MAP` so adding entries doesn't churn it.

Two things I noticed but left out of scope, tell me if you'd like either as a follow-up:

- `tileCount` is also returned by the search API and isn't in `INVENTORY_KEY_MAP`.
- `DKISTFileManager._download_dataset` adds `qualityReportObjectKey` to the Globus transfer file list; it doesn't add the new quality data file. That's a behaviour change rather than a naming one, so I've not touched it.
